### PR TITLE
feat(quest): rename quest_clear → quest_fulfill with backward-compat alias (QUEST-106)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ blocked on QUEST-42 is now available for whoever walks in next.
 
 ```bash
 guild quest brief "shipped retry in commit abc1234; QUEST-43 ready to start"
-guild quest clear QUEST-42 --report "done, shipped in abc1234"
+guild quest fulfill QUEST-42 --report "done, shipped in abc1234"
 ```
 
 Tomorrow's agent — same project, maybe a different MCP client — opens

--- a/docs/generated/cli.md
+++ b/docs/generated/cli.md
@@ -45,8 +45,8 @@ Every `guild <verb>` subcommand generated from the live cobra tree.
 - [`guild quest brief`](#guild-quest-brief) — write session-end handoff for the next agent
 - [`guild quest campaign`](#guild-quest-campaign) — bulk-set campaign
 - [`guild quest campfire`](#guild-quest-campfire) — save working state before compaction
-- [`guild quest clear`](#guild-quest-clear) — complete a quest (cascades unblock)
 - [`guild quest forfeit`](#guild-quest-forfeit) — release a claim without completing
+- [`guild quest fulfill`](#guild-quest-fulfill) — fulfill a quest (cascades unblock)
 - [`guild quest guild`](#guild-quest-guild) — per-project summary by campaign
 - [`guild quest init`](#guild-quest-init) — register this repo as a guild project
 - [`guild quest journal`](#guild-quest-journal) — append a task-scoped journal note
@@ -811,25 +811,6 @@ Save a structured working-state checkpoint (hypothesis, tried, next, token warni
 | `--token-warning` | bool | `false` | context window is running low |
 | `--tried` | stringArray | `[]` | approach tried (repeatable) |
 
-## `guild quest clear`
-
-complete a quest (cascades unblock)
-
-**Usage**
-
-```
-guild quest clear QUEST_ID [flags]
-```
-
-Complete a quest. Report is REQUIRED — commit hash, files, remaining issues. Cascades unblock dependent quests.
-
-**Flags**
-
-| flag | type | default | description |
-| --- | --- | --- | --- |
-| `--json` | bool | `false` | emit structured JSON result instead of formatted text |
-| `--report` | string | `—` | completion report: commit hash, files, remaining issues |
-
 ## `guild quest forfeit`
 
 release a claim without completing
@@ -848,6 +829,27 @@ Release a claimed quest back to the queue. Use when blocked or ceding to another
 | --- | --- | --- | --- |
 | `--json` | bool | `false` | emit structured JSON result instead of formatted text |
 | `--note` | string | `—` | reason the claim is being released (optional) |
+
+## `guild quest fulfill`
+
+fulfill a quest (cascades unblock)
+
+**Usage**
+
+```
+guild quest fulfill QUEST_ID [flags]
+```
+
+**Aliases:** clear
+
+Fulfill a quest. Report is REQUIRED — commit hash, files, remaining issues. Cascades unblock dependent quests.
+
+**Flags**
+
+| flag | type | default | description |
+| --- | --- | --- | --- |
+| `--json` | bool | `false` | emit structured JSON result instead of formatted text |
+| `--report` | string | `—` | completion report: commit hash, files, remaining issues |
 
 ## `guild quest guild`
 

--- a/docs/generated/mcp.md
+++ b/docs/generated/mcp.md
@@ -2,7 +2,7 @@
 
 # guild MCP tool catalog
 
-Every tool a registered MCP client sees. 37 tools.
+Every tool a registered MCP client sees. 38 tools.
 
 ## Tools
 
@@ -31,9 +31,10 @@ Every tool a registered MCP client sees. 37 tools.
 - [`quest_bounties`](#quest_bounties) — On-demand session snapshot: brief, oath, echoes, top task, and parallel candidates.
 - [`quest_brief`](#quest_brief) — Session-end briefing for the next agent.
 - [`quest_campfire`](#quest_campfire) — Save a structured working-state checkpoint (hypothesis, tried, next, token warning) before the context compacts.
-- [`quest_clear`](#quest_clear) — Complete a quest.
+- [`quest_clear`](#quest_clear) — Fulfill a quest.
 - [`quest_epic`](#quest_epic) — Set the campaign name on a batch of quests.
 - [`quest_forfeit`](#quest_forfeit) — Release a claimed quest back to the queue.
+- [`quest_fulfill`](#quest_fulfill) — Fulfill a quest.
 - [`quest_guild`](#quest_guild) — Per-project quest summary grouped by campaign: counts of next, in-progress, blocked, and done quests.
 - [`quest_journal`](#quest_journal) — Task-scoped scratchpad.
 - [`quest_list`](#quest_list) — All open tasks.
@@ -914,7 +915,7 @@ _no arguments_
 
 ## `quest_clear`
 
-Complete a quest. Report is REQUIRED — commit hash, files, remaining issues. Cascades unblock dependent quests.
+Fulfill a quest. Report is REQUIRED — commit hash, files, remaining issues. Cascades unblock dependent quests.
 
 _no arguments_
 
@@ -928,7 +929,7 @@ _no arguments_
       "type": "string"
     },
     "quest_id": {
-      "description": "QUEST-NNN to mark complete",
+      "description": "QUEST-NNN to fulfill",
       "type": "string"
     },
     "report": {
@@ -1015,6 +1016,40 @@ _no arguments_
   },
   "required": [
     "quest_id"
+  ],
+  "type": "object"
+}
+```
+
+</details>
+
+## `quest_fulfill`
+
+Fulfill a quest. Report is REQUIRED — commit hash, files, remaining issues. Cascades unblock dependent quests.
+
+_no arguments_
+
+<details><summary>Raw JSON schema</summary>
+
+```json
+{
+  "additionalProperties": false,
+  "properties": {
+    "project": {
+      "type": "string"
+    },
+    "quest_id": {
+      "description": "QUEST-NNN to fulfill",
+      "type": "string"
+    },
+    "report": {
+      "description": "specific completion report: commit hash, files, issues — REQUIRED",
+      "type": "string"
+    }
+  },
+  "required": [
+    "quest_id",
+    "report"
   ],
   "type": "object"
 }

--- a/internal/cli/quest.go
+++ b/internal/cli/quest.go
@@ -149,7 +149,7 @@ func init() {
 	// concern, not verb concern). See docs/architecture/COMMAND_REGISTRY.md.
 	deps := buildCLICommandDeps()
 	bindRegistryVerb(questCmd, quest.AcceptCommand, deps, "quest accept")
-	bindRegistryVerb(questCmd, quest.ClearCommand, deps, "quest clear")
+	bindRegistryVerb(questCmd, quest.FulfillCommand, deps, "quest fulfill")
 	bindRegistryVerb(questCmd, quest.ForfeitCommand, deps, "quest forfeit")
 	bindRegistryVerb(questCmd, quest.JournalCommand, deps, "quest journal")
 	bindRegistryVerb(questCmd, quest.BriefCommand, deps, "quest brief")

--- a/internal/cli/quest_test.go
+++ b/internal/cli/quest_test.go
@@ -68,17 +68,15 @@ func TestCLI_QuestPostClearRoundTrip(t *testing.T) {
 		t.Errorf("post stdout = %q, want contains 'posted QUEST-1: hello world'", stdout)
 	}
 
-	// Clear.
+	// Fulfill (via the `clear` cobra alias to verify QUEST-106 backward compat).
 	stdout, _, err = runQuest(t, []string{"quest", "clear",
 		"--project", "guild-cli-test",
 		"QUEST-1", "--report", "commit abc"})
 	if err != nil {
-		t.Fatalf("clear: %v", err)
+		t.Fatalf("fulfill: %v", err)
 	}
-	// QUEST-45 unified clear output — was "quest cleared: X", now matches
-	// MCP's "cleared X" header with an indented unblocked block.
-	if !strings.Contains(stdout, "cleared QUEST-1") {
-		t.Errorf("clear stdout = %q, want to contain 'cleared QUEST-1'", stdout)
+	if !strings.Contains(stdout, "fulfilled QUEST-1") {
+		t.Errorf("fulfill stdout = %q, want to contain 'fulfilled QUEST-1'", stdout)
 	}
 }
 
@@ -94,18 +92,17 @@ func TestCLI_QuestPostCascade(t *testing.T) {
 		"--depends-on", "QUEST-1", "B"}); err != nil {
 		t.Fatalf("post B: %v", err)
 	}
-	// Clear A — expect cascade 🔓 line for QUEST-2.
-	stdout, _, err := runQuest(t, []string{"quest", "clear", "-p", "guild-cli-casc", "QUEST-1"})
+	// Fulfill A — expect cascade line for QUEST-2. Using `fulfill` as
+	// primary verb (QUEST-106).
+	stdout, _, err := runQuest(t, []string{"quest", "fulfill", "-p", "guild-cli-casc", "QUEST-1"})
 	if err != nil {
-		t.Fatalf("clear A: %v", err)
+		t.Fatalf("fulfill A: %v", err)
 	}
-	// QUEST-45 unified clear output — cascade list is now indented
-	// under "unblocked:" rather than one "unblocked: <ID>" line.
-	if !strings.Contains(stdout, "cleared QUEST-1") {
-		t.Errorf("clear stdout missing cleared: %q", stdout)
+	if !strings.Contains(stdout, "fulfilled QUEST-1") {
+		t.Errorf("fulfill stdout missing fulfilled: %q", stdout)
 	}
 	if !strings.Contains(stdout, "QUEST-2") || !strings.Contains(stdout, "unblocked") {
-		t.Errorf("clear stdout missing cascade: %q", stdout)
+		t.Errorf("fulfill stdout missing cascade: %q", stdout)
 	}
 }
 

--- a/internal/mcp/budget_test.go
+++ b/internal/mcp/budget_test.go
@@ -26,8 +26,11 @@ const (
 	// registered tools (descriptions + input schemas). Raised to 4500
 	// in QUEST-101 to accommodate the 5 previously-deferred tools
 	// (lore_seal, lore_catalog, quest_epic, quest_active, quest_forfeit)
-	// now in the always-on tier. Expected actual: ~4100-4300 tokens.
-	totalMaxTokens = 4500
+	// now in the always-on tier. Raised to 4700 in QUEST-106 when
+	// quest_fulfill was added alongside quest_clear as a backward-compat
+	// alias — net +~100 tokens for the duplicate tool. Expected actual:
+	// ~4400-4600 tokens.
+	totalMaxTokens = 4700
 )
 
 // TestDescriptionBudget enforces the token budgets against the full

--- a/internal/mcp/instructions.md
+++ b/internal/mcp/instructions.md
@@ -2,7 +2,7 @@ You are working with a persistent agent-memory (**lore**) and task-coordination 
 
 Together they make agents as autonomous as possible. The core loop runs without a human between tasks:
 
-  quest_bounties → quest_accept → work → quest_clear(report=...) → quest_bounties → ...
+  quest_bounties → quest_accept → work → quest_fulfill(report=...) → quest_bounties → ...
 
 Every adventurer is transient; the guild is eternal. Your job is to take a bounty, do it well, inscribe what's worth keeping, brief the next arrival, and end cleanly.
 
@@ -132,12 +132,12 @@ If results are current, use them — do not re-research. If empty or stale, rese
 
 **You finished a quest:**
 ```
-quest_clear(
+quest_fulfill(
   quest_id="QUEST-42",
   report="Fixed the race in retry budget accounting. Commit abc1234. Tests added in budget_test.go."
 )
 ```
-Report is REQUIRED. Be specific.
+Report is REQUIRED. Be specific. `quest_clear(quest_id="...", report="...")` also works as a backward-compat alias.
 
 **You hit a wall mid-quest and the context window is warning you:**
 ```
@@ -231,7 +231,7 @@ Use these shapes when you need a concrete schema:
   quest_accept(quest_id="QUEST-7")
   quest_journal(quest_id="QUEST-7", text="Found race in retry budget accounting.")
   quest_campfire(quest_id="QUEST-7", hypothesis="budget race", next="inspect retry state")
-  quest_clear(quest_id="QUEST-7", report="done in abc123; tests added")
+  quest_fulfill(quest_id="QUEST-7", report="done in abc123; tests added")
   quest_brief(text="Retry budget shipped; next session should profile p99 latency.")
   quest_bounties()
   quest_list(status="next")

--- a/internal/mcp/instructions_test.go
+++ b/internal/mcp/instructions_test.go
@@ -23,8 +23,9 @@ import (
 // direct edits to instructions.md do. See QUEST-57 for the dynamic
 // build path and its separate tests.
 //
-// Last updated for the lazy-load tool-discovery note (Codex + Cursor).
-const wantStaticSHA = "325854527015b8efd79ab5d9b2b672119d196633fd9fad51f357150813135d48"
+// Last updated for QUEST-106: quest_clear → quest_fulfill rename with
+// backward-compat alias note.
+const wantStaticSHA = "4508848753ecaadb59348e720797424b1452469ab98ff8353893d5507a49481a"
 
 func TestStaticInstructions_Embedded(t *testing.T) {
 	if staticInstructions == "" {

--- a/internal/mcp/register.go
+++ b/internal/mcp/register.go
@@ -94,6 +94,10 @@ func registerAlwaysOn(s *sdkmcp.Server) {
 	quest.AcceptCommand.BindMCP(s, mcpDeps)
 	quest.JournalCommand.BindMCP(s, mcpDeps)
 	quest.CampfireCommand.BindMCP(s, mcpDeps)
+	quest.FulfillCommand.BindMCP(s, mcpDeps)
+	// quest_clear is kept as a backward-compat MCP alias (same handler,
+	// different tool name) so agents trained on the pre-QUEST-106 verb
+	// still work. Tool discovery surfaces both; new agents prefer fulfill.
 	quest.ClearCommand.BindMCP(s, mcpDeps)
 	quest.BriefCommand.BindMCP(s, mcpDeps)
 	quest.SummonCommand.BindMCP(s, mcpDeps)

--- a/internal/mcp/smoke_full_test.go
+++ b/internal/mcp/smoke_full_test.go
@@ -60,6 +60,7 @@ var toolArgSpecs = map[string][]command.ArgSpec{
 	"quest_clear":    quest.ClearCommand.Args,
 	"quest_epic":     quest.EpicCommand.Args,
 	"quest_forfeit":  quest.ForfeitCommand.Args,
+	"quest_fulfill":  quest.FulfillCommand.Args,
 	"quest_guild":    quest.GuildCommand.Args,
 	"quest_journal":  quest.JournalCommand.Args,
 	"quest_list":     quest.ListCommand.Args,

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -46,9 +46,10 @@ var expectedTools = []struct {
 	{"quest_bounties"},
 	{"quest_brief"},
 	{"quest_campfire"},
-	{"quest_clear"},
+	{"quest_clear"}, // backward-compat alias for quest_fulfill (QUEST-106)
 	{"quest_epic"},
 	{"quest_forfeit"},
+	{"quest_fulfill"},
 	{"quest_guild"},
 	{"quest_journal"},
 	{"quest_list"},
@@ -709,6 +710,8 @@ func minArgsFor(name string) map[string]any {
 		return map[string]any{"quest_id": "QUEST-1"}
 	case "quest_clear":
 		return map[string]any{"quest_id": "QUEST-1", "report": "r"}
+	case "quest_fulfill":
+		return map[string]any{"quest_id": "QUEST-1", "report": "r"}
 	case "quest_journal":
 		return map[string]any{"quest_id": "QUEST-1", "text": "t"}
 	case "quest_brief":
@@ -789,6 +792,11 @@ func smokeArgsFor(name string) map[string]any {
 	case "quest_journal":
 		return map[string]any{"quest_id": "QUEST-99999", "text": "t", "project": "testproj"}
 	case "quest_clear":
+		return map[string]any{
+			"quest_id": "QUEST-99999", "report": "r",
+			"project": "testproj",
+		}
+	case "quest_fulfill":
 		return map[string]any{
 			"quest_id": "QUEST-99999", "report": "r",
 			"project": "testproj",

--- a/internal/quest/clear.go
+++ b/internal/quest/clear.go
@@ -9,9 +9,13 @@ import (
 	"time"
 )
 
-// Clear marks taskID as status='done' and atomically runs the cascade-
+// Clear is a backward-compat alias for Fulfill. Existing callers keep
+// compiling; new code should call Fulfill directly. QUEST-106 / LORE-80.
+var Clear = Fulfill
+
+// Fulfill marks taskID as status='done' and atomically runs the cascade-
 // unblock pass: every quest currently in status='blocked' whose full
-// depends_on list is satisfied by the post-Clear done-set flips to
+// depends_on list is satisfied by the post-Fulfill done-set flips to
 // status='next'.
 //
 // Non-negotiable correctness (QUEST-9 spec): the cascade must find
@@ -28,7 +32,7 @@ import (
 // payload) and as a `[completed] <report>` note in task_notes for
 // chronological history. If `report` is empty, only the event fires
 // (no note).
-func Clear(ctx context.Context, db *sql.DB, projectID, taskID, report string) (*ClearResult, error) {
+func Fulfill(ctx context.Context, db *sql.DB, projectID, taskID, report string) (*FulfillResult, error) {
 	if db == nil {
 		return nil, fmt.Errorf("quest: clear: nil db")
 	}
@@ -114,5 +118,5 @@ func Clear(ctx context.Context, db *sql.DB, projectID, taskID, report string) (*
 	if err := tx.Commit(); err != nil {
 		return nil, fmt.Errorf("quest: clear: commit: %w", err)
 	}
-	return &ClearResult{Cleared: cleared, Unblocked: unblocked}, nil
+	return &FulfillResult{Cleared: cleared, Unblocked: unblocked}, nil
 }

--- a/internal/quest/clear_cmd.go
+++ b/internal/quest/clear_cmd.go
@@ -10,35 +10,45 @@ import (
 	"github.com/mathomhaus/guild/internal/command"
 )
 
-type ClearInput struct {
-	QuestID string `json:"quest_id" jsonschema:"QUEST-NNN to mark complete"`
+// FulfillInput carries the args for quest fulfillment.
+// ClearInput is a backward-compat type alias.
+type FulfillInput struct {
+	QuestID string `json:"quest_id" jsonschema:"QUEST-NNN to fulfill"`
 	Report  string `json:"report" jsonschema:"specific completion report: commit hash, files, issues — REQUIRED"`
 	Project string `json:"project,omitempty"`
 }
 
-type ClearOutput struct {
-	Result    *ClearResult `json:"result"`
-	BriefHint string       `json:"brief_hint,omitempty"`
+type FulfillOutput struct {
+	Result    *FulfillResult `json:"result"`
+	BriefHint string         `json:"brief_hint,omitempty"`
 }
 
-var ClearCommand = &command.Command[ClearInput, ClearOutput]{
-	Name:    "quest_clear",
-	CLIPath: []string{"quest", "clear"},
-	Short:   "complete a quest (cascades unblock)",
-	Long:    "Complete a quest. Report is REQUIRED — commit hash, files, remaining issues. Cascades unblock dependent quests.",
+// Backward-compat type aliases so existing callers keep compiling.
+type ClearInput = FulfillInput
+type ClearOutput = FulfillOutput
+
+// FulfillCommand is the primary quest-completion verb. `quest clear` stays
+// as a cobra alias for muscle-memory; `quest_fulfill` is the canonical MCP
+// tool name. QUEST-106 / LORE-80.
+var FulfillCommand = &command.Command[FulfillInput, FulfillOutput]{
+	Name:       "quest_fulfill",
+	CLIPath:    []string{"quest", "fulfill"},
+	CLIAliases: []string{"clear"},
+	Short:      "fulfill a quest (cascades unblock)",
+	Long:       "Fulfill a quest. Report is REQUIRED — commit hash, files, remaining issues. Cascades unblock dependent quests.",
 	Args: []command.ArgSpec{
 		{
 			Name:     "quest_id",
 			Kind:     command.ArgPositional,
 			Type:     command.ArgString,
 			Required: true,
-			Help:     "QUEST-NNN to mark complete",
+			Help:     "QUEST-NNN to mark fulfilled",
 		},
 		{
 			Name: "report",
 			Kind: command.ArgFlag,
 			Type: command.ArgString,
-			// Not Required at the domain layer — Clear() accepts empty
+			// Not Required at the domain layer — Fulfill() accepts empty
 			// report and just writes the `done` event without a
 			// [completed] note. Encourage callers to pass one via Help
 			// phrasing, don't reject the call.
@@ -52,62 +62,74 @@ var ClearCommand = &command.Command[ClearInput, ClearOutput]{
 			Help:  "project override",
 		},
 	},
-	Handler: func(ctx context.Context, d command.Deps, in ClearInput) (ClearOutput, error) {
+	Handler: func(ctx context.Context, d command.Deps, in FulfillInput) (FulfillOutput, error) {
 		if strings.TrimSpace(in.QuestID) == "" {
-			return ClearOutput{}, errors.New("quest_id required")
+			return FulfillOutput{}, errors.New("quest_id required")
 		}
 		db, err := d.OpenDB(ctx)
 		if err != nil {
-			return ClearOutput{}, err
+			return FulfillOutput{}, err
 		}
 		defer func() { _ = db.Close() }()
 
 		pid, err := d.ResolveProj(ctx, in.Project)
 		if err != nil {
-			return ClearOutput{}, err
+			return FulfillOutput{}, err
 		}
-		res, err := Clear(ctx, db, pid, in.QuestID, in.Report)
+		res, err := Fulfill(ctx, db, pid, in.QuestID, in.Report)
 		if err != nil {
-			return ClearOutput{}, err
+			return FulfillOutput{}, err
 		}
 
-		out := ClearOutput{Result: res}
+		out := FulfillOutput{Result: res}
 
 		// Advisory hint: if no brief has been written recently, remind the
-		// caller to write a handoff before compacting. This is shipped via
-		// two paths, live together during the QUEST-58 migration window:
+		// caller to write a handoff before compacting. Two paths coexist
+		// during the QUEST-58 migration window:
 		//
 		//   1. HintExtras signal — the hint engine's no-brief-24h rule reads
 		//      __hints_brief_stale and fires the canonical 💡 line. Preferred.
 		//   2. out.BriefHint — legacy field; still populated so CLI paths
-		//      that don't yet route through the engine (and backward-compat
-		//      consumers of ClearOutput) keep their hint. The MCP format
-		//      function drops it when the engine is wired so we don't
-		//      render twice.
+		//      that don't yet route through the engine keep their hint. The
+		//      MCP format function drops it when the engine is wired so we
+		//      don't render twice.
 		lastAt, briefErr := LastBriefAt(ctx, db, pid)
-		stale := briefErr == nil && (lastAt.IsZero() || time.Now().Sub(lastAt) > briefStaleThreshold)
+		stale := briefErr == nil && (lastAt.IsZero() || time.Since(lastAt) > briefStaleThreshold)
 		if stale {
 			if extras := command.HintExtras(ctx); extras != nil {
 				extras["__hints_brief_stale"] = true
 			} else {
-				// No engine wired (test or cold-path CLI surface) — fall
-				// back to the legacy field so output stays consistent.
 				out.BriefHint = `no quest_brief yet this session — consider quest_brief("what was done, what's next") before compact`
 			}
 		}
 
 		return out, nil
 	},
-	CLIFormat:      func(s command.CLISink, o ClearOutput) string { return formatCleared(s, o) },
-	MCPFormat:      func(s command.MCPSink, o ClearOutput) string { return formatCleared(s, o) },
-	CLIErrorFormat: func(s command.CLISink, err error) (string, bool) { return formatClearError(s, err) },
-	MCPErrorFormat: func(s command.MCPSink, err error) (string, bool) { return formatClearError(s, err) },
+	CLIFormat:      func(s command.CLISink, o FulfillOutput) string { return formatFulfilled(s, o) },
+	MCPFormat:      func(s command.MCPSink, o FulfillOutput) string { return formatFulfilled(s, o) },
+	CLIErrorFormat: func(s command.CLISink, err error) (string, bool) { return formatFulfillError(s, err) },
+	MCPErrorFormat: func(s command.MCPSink, err error) (string, bool) { return formatFulfillError(s, err) },
 }
 
-func formatCleared(s lineListSink, o ClearOutput) string {
+// ClearCommand is the backward-compat MCP alias for FulfillCommand. It
+// points at the same handler + formatters; only the tool name differs.
+// Agents trained on `quest_clear` still work; new agents see `quest_fulfill`
+// in tool discovery. CLIOnly=false, MCPOnly=true — CLI alias is handled
+// via FulfillCommand.CLIAliases, so this struct stays off the CLI surface
+// to avoid duplicate cobra verbs.
+var ClearCommand = func() *command.Command[FulfillInput, FulfillOutput] {
+	c := *FulfillCommand
+	c.Name = "quest_clear"
+	c.MCPOnly = true
+	c.CLIAliases = nil // avoid cobra registering an orphan alias
+	c.Short = "fulfill a quest (alias for quest_fulfill; cascades unblock)"
+	return &c
+}()
+
+func formatFulfilled(s lineListSink, o FulfillOutput) string {
 	res := o.Result
 	var b strings.Builder
-	b.WriteString(s.Line("🏆", "[cleared]", fmt.Sprintf("cleared %s", res.Cleared.ID)))
+	b.WriteString(s.Line("🏆", "[fulfilled]", fmt.Sprintf("fulfilled %s", res.Cleared.ID)))
 	if len(res.Unblocked) > 0 {
 		b.WriteString("  unblocked:\n")
 		for _, q := range res.Unblocked {
@@ -124,9 +146,9 @@ func formatCleared(s lineListSink, o ClearOutput) string {
 	return strings.TrimRight(b.String(), "\n")
 }
 
-func formatClearError(s lineListSink, err error) (string, bool) {
+func formatFulfillError(s lineListSink, err error) (string, bool) {
 	if errors.Is(err, ErrNotFound) {
-		msg := fmt.Sprintf("quest_clear: %v", err)
+		msg := fmt.Sprintf("quest_fulfill: %v", err)
 		return strings.TrimRight(s.Line("❌", "[err]", msg), "\n"), true
 	}
 	return "", false

--- a/internal/quest/clear_cmd_test.go
+++ b/internal/quest/clear_cmd_test.go
@@ -10,20 +10,31 @@ import (
 	"github.com/mathomhaus/guild/internal/quest"
 )
 
-func TestClearCommand_CobraSurface(t *testing.T) {
+// TestFulfillCommand_CobraSurface verifies the primary verb + backward-compat
+// alias both land on cobra: `quest fulfill` is the primary subcommand, and
+// `quest clear` is surfaced via CLIAliases.
+func TestFulfillCommand_CobraSurface(t *testing.T) {
 	parent := &cobra.Command{Use: "quest"}
 	parent.PersistentFlags().StringP("project", "p", "", "project")
-	quest.ClearCommand.BindCobra(parent, fakeDeps(t))
+	quest.FulfillCommand.BindCobra(parent, fakeDeps(t))
 
-	sub := findSubcommand(parent, "clear")
+	sub := findSubcommand(parent, "fulfill")
 	if sub == nil {
-		t.Fatal("clear subcommand not registered")
+		t.Fatal("fulfill subcommand not registered")
 	}
-	if got, want := sub.Use, "clear QUEST_ID"; got != want {
+	if got, want := sub.Use, "fulfill QUEST_ID"; got != want {
 		t.Errorf("Use=%q want %q", got, want)
 	}
-	if sub.Short != quest.ClearCommand.Short {
-		t.Errorf("Short=%q want %q", sub.Short, quest.ClearCommand.Short)
+	// cobra Aliases should include "clear" for muscle-memory users.
+	foundAlias := false
+	for _, a := range sub.Aliases {
+		if a == "clear" {
+			foundAlias = true
+			break
+		}
+	}
+	if !foundAlias {
+		t.Errorf("expected `clear` among aliases, got %v", sub.Aliases)
 	}
 	for _, want := range []string{"report", "json"} {
 		if sub.Flags().Lookup(want) == nil {
@@ -36,12 +47,14 @@ func TestClearCommand_CobraSurface(t *testing.T) {
 	}
 }
 
-func TestClearCommand_MCPSurface(t *testing.T) {
-	tool := quest.ClearCommand.BuildMCPForTest(fakeDeps(t))
-	if tool.Name != "quest_clear" {
-		t.Errorf("Name=%q want quest_clear", tool.Name)
+// TestFulfillCommand_MCPSurface verifies the canonical MCP tool is named
+// `quest_fulfill` and carries the new "Fulfill a quest" description.
+func TestFulfillCommand_MCPSurface(t *testing.T) {
+	tool := quest.FulfillCommand.BuildMCPForTest(fakeDeps(t))
+	if tool.Name != "quest_fulfill" {
+		t.Errorf("Name=%q want quest_fulfill", tool.Name)
 	}
-	if !strings.HasPrefix(tool.Description, "Complete a quest") {
+	if !strings.HasPrefix(tool.Description, "Fulfill a quest") {
 		t.Errorf("Description=%q", tool.Description)
 	}
 	buf, _ := json.Marshal(tool.InputSchema)
@@ -50,6 +63,20 @@ func TestClearCommand_MCPSurface(t *testing.T) {
 		if !strings.Contains(schema, want) {
 			t.Errorf("schema missing %s:\n%s", want, schema)
 		}
+	}
+}
+
+// TestClearCommand_MCPBackwardCompat verifies the MCP-only alias tool is
+// still advertised under the legacy name `quest_clear` so agents trained
+// on the pre-QUEST-106 verb continue to work.
+func TestClearCommand_MCPBackwardCompat(t *testing.T) {
+	tool := quest.ClearCommand.BuildMCPForTest(fakeDeps(t))
+	if tool.Name != "quest_clear" {
+		t.Errorf("Name=%q want quest_clear (backward-compat alias)", tool.Name)
+	}
+	// Description should still reference fulfill semantics.
+	if !strings.Contains(tool.Description, "Fulfill") {
+		t.Errorf("alias description should reference fulfill; got %q", tool.Description)
 	}
 }
 

--- a/internal/quest/types.go
+++ b/internal/quest/types.go
@@ -180,13 +180,17 @@ func (p *UpdateParams) Empty() bool {
 	return true
 }
 
-// ClearResult is returned by Clear. Cleared is the freshly-done quest;
-// Unblocked lists every quest whose `blocked → next` flip was caused
-// by this Clear call (cascade-unblock invariant).
-type ClearResult struct {
+// FulfillResult is returned by Fulfill. Cleared is the freshly-done quest;
+// Unblocked lists every quest whose `blocked → next` flip was caused by
+// this Fulfill call (cascade-unblock invariant). The `Cleared` field name
+// is preserved for backward compat in callers; the semantics are the same.
+type FulfillResult struct {
 	Cleared   *Quest
 	Unblocked []*Quest
 }
+
+// ClearResult is a backward-compat type alias for FulfillResult.
+type ClearResult = FulfillResult
 
 // ForfeitResult is returned by Forfeit. Quest is the target quest's
 // current state. AlreadyNext is true when Forfeit was a no-op because


### PR DESCRIPTION
## Summary
Renames the quest-completion verb from `clear` to `fulfill`. `clear` stays as a backward-compat alias on both CLI (cobra alias) and MCP (alias tool pointing at the same handler) so agents trained on the old verb keep working.

Motivated by user feedback that `quest_clear` reads as "wipe/delete" to plain-English readers, opposite of the intent. `fulfill` is unambiguous and fits the fantasy vocabulary (classic RPG verb). Same pattern as QUEST-16's epic→campaign rename.

## Linked quest or issue
QUEST-106 / LORE-80 (internal board).

## Test plan
- [x] `make check` passes locally (fmt + vet + lint + sqlcheck + test-race + docs)
- [x] New + updated regression tests:
  - `TestFulfillCommand_CobraSurface` — primary verb registered, `clear` among cobra aliases
  - `TestFulfillCommand_MCPSurface` — primary MCP tool `quest_fulfill` with "Fulfill a quest" description
  - `TestClearCommand_MCPBackwardCompat` — alias tool `quest_clear` still registered
  - Updated `TestCLI_QuestPostClearRoundTrip` (exercises the `clear` cobra alias) + `TestCLI_QuestPostCascade` (uses `fulfill` primary)
- [x] Manually exercised:
  - `guild quest fulfill QUEST-X --report "..."` works
  - `guild quest clear QUEST-X --report "..."` still works (alias)
  - MCP `quest_fulfill` and `quest_clear` both callable

## Notes for reviewers
- Budget ceiling bumped from 4500 → 4700 in `budget_test.go` to absorb the duplicate tool (~+100 tokens). Real cost lands around 4600 per latest run — still well within comfort.
- The hint engine's `no-brief-24h` rule still has `quest_clear` as its `trigger_tool` in the migration seed. When agents call `quest_fulfill` directly, the hint won't fire for them. Leaving this for a follow-up so we don't bundle hint-rule migration with the rename.
- Type aliases and the `var Clear = Fulfill` shim keep internal callers and existing tests compiling without a sweep through the quest package.
- INSTRUCTIONS.md hash regenerated in `wantStaticSHA`; docs/generated/* regenerated via `make docs`.