### PR TITLE
chore(ci): add PR hygiene automation — auto-label, size-label, title lint, release drafter

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,54 @@
+"area: lore":
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'internal/lore/**'
+      - 'internal/cli/lore*'
+
+"area: quest":
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'internal/quest/**'
+      - 'internal/cli/quest*'
+
+"area: cli":
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'internal/cli/**'
+      - 'cmd/guild/**'
+
+"area: mcp":
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'internal/mcp/**'
+
+"area: hints":
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'internal/hints/**'
+
+"area: install":
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'internal/install/**'
+      - 'scripts/install*'
+      - '.goreleaser.yml'
+      - 'Formula/**'
+
+"area: docs":
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'docs/**'
+      - 'README.md'
+      - '**/*.md'
+
+"area: ci":
+  - changed-files:
+    - any-glob-to-any-file:
+      - '.github/**'
+      - 'Makefile'
+
+dependencies:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'go.mod'
+      - 'go.sum'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,54 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+
+categories:
+  - title: 'Features'
+    labels:
+      - 'enhancement'
+  - title: 'Bug Fixes'
+    labels:
+      - 'bug'
+  - title: 'Performance'
+    labels:
+      - 'performance'
+  - title: 'Security'
+    labels:
+      - 'security'
+  - title: 'Dependencies'
+    labels:
+      - 'dependencies'
+  - title: 'Documentation'
+    labels:
+      - 'documentation'
+      - 'area: docs'
+  - title: 'Maintenance'
+    labels:
+      - 'chore'
+
+change-template: '- $TITLE (#$NUMBER) @$AUTHOR'
+change-title-escapes: '\<*_&'
+
+version-resolver:
+  major:
+    labels:
+      - 'breaking-change'
+  minor:
+    labels:
+      - 'enhancement'
+  patch:
+    labels:
+      - 'bug'
+      - 'dependencies'
+      - 'chore'
+      - 'documentation'
+  default: patch
+
+exclude-labels:
+  - 'skip-changelog'
+
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  **Full Changelog**: https://github.com/mathomhaus/guild/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,18 @@
+name: Labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          sync-labels: true

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -1,0 +1,74 @@
+name: PR Hygiene
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  semantic-title:
+    name: semantic PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            chore
+            docs
+            refactor
+            ci
+            test
+            build
+            perf
+          scopes: |
+            quest
+            lore
+            mcp
+            cli
+            init
+            install
+            hints
+            ci
+            release
+            docs
+            readme
+            deps
+            issues
+          requireScope: false
+          subjectPattern: ^[^A-Z].+$
+          subjectPatternError: |
+            The subject "{subject}" found in PR title "{title}"
+            didn't match the configured pattern. Subject should not start
+            with an uppercase character.
+
+  size-label:
+    name: size label
+    runs-on: ubuntu-latest
+    steps:
+      - uses: codelytv/pr-size-labeler@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          xs_label: 'size: XS'
+          xs_max_size: '10'
+          s_label: 'size: S'
+          s_max_size: '50'
+          m_label: 'size: M'
+          m_max_size: '200'
+          l_label: 'size: L'
+          l_max_size: '500'
+          xl_label: 'size: XL'
+          fail_if_xl: 'false'
+          message_if_xl: >
+            This PR exceeds 500 LOC. Consider splitting into smaller PRs
+            for easier review. Not a hard block.
+          files_to_ignore: |
+            go.sum
+            docs/generated/**
+            docs/assets/**

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,11 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
 
 permissions:
   contents: read

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,27 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Four independent, opt-in-by-nature GHA automations for PR triage. All label-only — **auto-merge is explicitly out of scope** per the user's ask (build confidence first before automating the merge button).

| Automation | Action | Trigger | Effect |
|---|---|---|---|
| Path labeler | `actions/labeler@v5` | `pull_request_target` | Applies `area: *` labels based on changed files |
| Size labeler | `codelytv/pr-size-labeler@v1` | `pull_request` | Applies `size: XS/S/M/L/XL` based on LOC delta |
| Title lint | `amannn/action-semantic-pull-request@v5` | `pull_request` | Fails if PR title isn't conventional-commit format |
| Release drafter | `release-drafter/release-drafter@v6` | push to `main` | Aggregates merged PRs into a rolling draft release |

## Files

- `.github/labeler.yml` — path-glob → label map (reuses existing `area: *` labels, adds `area: hints`, `area: ci`)
- `.github/workflows/labeler.yml` — runs `actions/labeler@v5` with `sync-labels: true`
- `.github/workflows/pr-hygiene.yml` — title lint + size labeler (two parallel jobs)
- `.github/release-drafter.yml` — category map: Features / Bug Fixes / Performance / Security / Dependencies / Documentation / Maintenance
- `.github/workflows/release-drafter.yml` — runs on push to main + PR events to keep the draft live

## Labels bootstrapped

Created via `gh label create` before this PR opened:

- `area: hints`, `area: ci` (color `#5319E7`, matches existing area palette)
- `size: XS` (green) / `S` / `M` (yellow) / `L` / `XL` (red) — graduated palette
- `chore`, `skip-changelog`

## Size thresholds

Tuned for guild's scale (most PRs are S–M):
- XS: <10 LOC
- S: <50
- M: <200
- L: <500
- XL: ≥500 (soft warn, not a block)

`go.sum`, `docs/generated/**`, `docs/assets/**` excluded from the size count so dependency bumps and doc regens don't inflate.

## Title lint config

- Allowed types: `feat`, `fix`, `chore`, `docs`, `refactor`, `ci`, `test`, `build`, `perf`
- Allowed scopes (optional): `quest`, `lore`, `mcp`, `cli`, `init`, `install`, `hints`, `ci`, `release`, `docs`, `readme`, `deps`, `issues`
- Subject must not start with uppercase (matches existing commit style)

## Release drafter

Complements the existing goreleaser tag-push flow: release-drafter keeps a rolling **draft** on the GitHub Releases page grouped by conventional-commit label (enhancement → Features, bug → Bug Fixes, etc.). When you push a `v*.*.*` tag, goreleaser cuts the actual release and the draft provides pre-curated notes. No runtime conflict — drafter only writes drafts; goreleaser consumes them.

## Test plan

- [x] YAML syntax validated (ruby `YAML.load_file`)
- [x] `actionlint` clean (exit 0 on all three workflow files)
- [x] `make check` passes (fmt / vet / lint / sqlcheck / test-race / docs-check)
- [ ] This PR itself is the first live test:
  - [ ] Labeler applies `area: ci` (changes in `.github/**`)
  - [ ] Size labeler applies `size: M` (~225 LOC YAML)
  - [ ] Title lint passes (`chore(ci): …`)
  - [ ] Release drafter updates the draft release after merge to main

## One-time reviewer setup

Nothing required — all labels already bootstrapped, all workflows self-contained, no secrets needed beyond `GITHUB_TOKEN` (auto-provided).

Optional, if not already on: **Settings → General → Pull Requests → Automatically delete head branches**. Pairs well with the labeler so stale branches don't pile up.

## Out of scope

- Auto-merge — deferred until confidence is built on manual merge flow
- Stale PR marker — solo repo, PRs shouldn't sit long
- CODEOWNERS — solo
- Greeter bot — solo

## Links

- Quest: QUEST-142
- Spec: LORE-126