### PR TITLE
docs: add fork-and-PR workflow for external contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,40 @@ open a Discussion before writing code.
 - Skim [`internal/mcp/instructions.go`](./internal/mcp/instructions.go) —
   this is the full operating contract the MCP server ships to clients.
 
+## Fork workflow (for external contributors)
+
+If you don't have push access to `mathomhaus/guild` — the default for
+anyone outside the core maintainer set — fork first, then work on a
+branch in your fork and open a PR against `mathomhaus/guild:main`.
+
+```bash
+gh repo fork mathomhaus/guild --clone
+cd guild
+git checkout -b short-descriptive-branch-name
+# ... make changes, commit ...
+git push origin short-descriptive-branch-name
+gh pr create --repo mathomhaus/guild
+```
+
+Or fork via the GitHub UI, then clone your fork locally. Either works.
+
+### Claiming an issue
+
+Comment `/assign` on an issue labeled `good first issue` or `help
+wanted` to claim it; use `/unassign` to release it if you need to drop
+it. (Until the assign bot is live, just say so in a comment — a
+maintainer will assign you.)
+
+Being assigned means the issue is yours to work on; it does **not**
+grant push access to this repo. You still fork and open a PR from
+your fork.
+
 ## Development setup
+
+This path is for contributors with push access (maintainers,
+collaborators). External contributors should use the
+[fork workflow](#fork-workflow-for-external-contributors) above
+instead.
 
 ```bash
 git clone https://github.com/mathomhaus/guild.git


### PR DESCRIPTION
## Summary

Adds a `Fork workflow (for external contributors)` section to `CONTRIBUTING.md`, positioned before `Development setup`, so outside contributors see the correct `gh repo fork` + `gh pr create` path before they try to clone the upstream repo and hit a push rejection.

Reframes `Development setup` as the maintainer/collaborator path and cross-links to the fork section for everyone else. Additive only — no other sections rewritten.

Ships as a Reddit-launch prerequisite: the current file has zero mention of fork-and-PR, so a first-wave external contributor reading it literally would be stuck at the push step. Observed concretely when a first-time external contributor asked to be assigned on an issue and the existing doc gave them no path forward.

## What changed

- New `## Fork workflow (for external contributors)` section with exact commands: `gh repo fork mathomhaus/guild --clone`, `gh pr create --repo mathomhaus/guild`.
- New `### Claiming an issue` subsection covering `/assign` and `/unassign`, phrased to work whether or not the assign bot is live yet (sibling work tracked separately).
- One clarifying sentence in `Development setup` scoping it to contributors with push access, with an anchor link back to the fork section.

## Linked quest or issue

QUEST-187 from the internal board.

## Test plan

- [x] `make check` passes locally (fmt + vet + lint + sqlcheck + test-race)
- [x] Rendered Markdown reads cleanly; the in-file anchor `#fork-workflow-for-external-contributors` resolves.
- [ ] No code changes — no new behavior tests required.

## Notes for reviewers

- Kept the file's existing tone (direct, no `$` prompt in code blocks) rather than introducing a new style.
- Skipped README / issue-template edits: README's `Contributing` pointer already sends readers to `CONTRIBUTING.md`, and no existing issue template mentions the contribution flow. Scope held tight on purpose.