### PR TITLE
docs(mcp): universalize instructions.md vocabulary for project-type-agnostic contract (QUEST-190)

### DIFF
--- a/internal/mcp/instructions.md
+++ b/internal/mcp/instructions.md
@@ -34,7 +34,7 @@ These apply ALWAYS. Not suggestions.
 
 4. **ALWAYS `quest_journal` OR `lore_inscribe` findings.** Task-scoped → journal. Transcends the task → lore. The test: *would a future agent on a different quest need this?*
 
-5. **ALWAYS pass `report` to `quest_clear`.** Required. Be specific: commit hash, files, remaining issues. "Done" is not a report.
+5. **ALWAYS pass `report` to `quest_clear`.** Required. Be specific: what changed, what remains, any blockers. "Done" is not a report.
 
 6. **Capture principles IMMEDIATELY when the human corrects you.** Before anything else, `lore_inscribe(kind="principle", ...)`. Principles auto-load into every future session's oath — this is how the correction sticks permanently.
 
@@ -50,7 +50,7 @@ These apply ALWAYS. Not suggestions.
 
 10. **Don't lore what's already in quest.** If it dies when the quest clears, it's a `quest_journal` entry, not `lore_inscribe`.
 
-11. **If grep can find it, it doesn't belong in lore.** Lore is for insights and principles no file search can surface. Don't index files — inscribe knowledge.
+11. **If a search can find it, it doesn't belong in lore.** Lore is for insights and principles no search can surface. Don't index project content — inscribe knowledge.
 
 12. **Don't ask permission for obvious entries.** Just inscribe. The human reviews via `lore_list` later.
 
@@ -107,9 +107,9 @@ A principle is a kind of lore entry (kind=principle). The oath is the rendered l
 
 **Principles MUST be ≤60 words** (title + summary combined). Long principles bloat every future session's oath and cost tokens forever. Anything longer is a *decision* in disguise — inscribe it as `kind=decision` and write a short principle that links to it via `lore_link`.
 
-**Lore summaries DISTILL the durable choice.** Implementation detail goes in the quest acceptance that prompted the inscription — not in the lore summary. A decision entry answers "what was decided and why" in 3–5 sentences; the acceptance bullets of the quest that triggered it carry the how.
+**Lore summaries DISTILL the durable choice.** Detail goes in the quest acceptance that prompted the inscription — not in the lore summary. A decision entry answers "what was decided and why" in 3–5 sentences; the acceptance bullets of the quest that triggered it carry the how.
 
-**Transfer reasoning lives in the lore summary; project artifacts carry implementation detail.** When a new entry cites an ancestor via `informs`, the summary must name the transfer in 1–3 sentences — why the ancestor applies HERE (delta, inversion, adoption, or triviality). Longer-form project artifacts — plan docs, PR descriptions, chapter drafts, research notes, spec outlines, whatever fits your project — carry deeper context, examples, and detail. Trivial transfers (same approach, no delta) get brief cites, but the brief cite still names the triviality in one clause. A bare "adopts LORE-N, same rationale applies" with no articulation of why it transfers is a rubber-stamp, not a cite — the lore body must stand alone as reasoning.
+**Transfer reasoning lives in the lore summary; project artifacts carry the detail.** When a new entry cites an ancestor via `informs`, the summary must name the transfer in 1–3 sentences — why the ancestor applies HERE (delta, inversion, adoption, or triviality). Longer-form project artifacts — plan docs, PR descriptions, chapter drafts, research notes, spec outlines, whatever fits your project — carry deeper context, examples, and detail. Trivial transfers (same approach, no delta) get brief cites, but the brief cite still names the triviality in one clause. A bare "adopts LORE-N, same rationale applies" with no articulation of why it transfers is a rubber-stamp, not a cite — the lore body must stand alone as reasoning.
 
 ## Task-shaped examples — situation → call
 

--- a/internal/mcp/instructions_test.go
+++ b/internal/mcp/instructions_test.go
@@ -23,13 +23,14 @@ import (
 // direct edits to instructions.md do. See QUEST-57 for the dynamic
 // build path and its separate tests.
 //
-// Last updated for QUEST-172 follow-up: universalize the reasoning-surface
-// paragraph so the MCP contract isn't locked to software-engineering
-// vocabulary — "project artifacts" as the collective term, with
-// non-exhaustive examples (plan docs, PR descriptions, chapter drafts,
-// research notes, spec outlines) so guild's project-type-agnostic posture
-// holds for writers, researchers, PMs, etc.
-const wantStaticSHA = "fb0aa8f2b1434382b441bffb5c4e4666f79494404fce62762df42601fd5170b6"
+// Last updated for QUEST-190: broader vocabulary audit — universalize
+// four dev-coded phrases so the MCP contract is project-type-agnostic:
+// (1) Rule 5 report guidance: "commit hash, files" → "what changed, what
+// remains"; (2) Rule 11: "grep" → "a search", "index files" → "index
+// project content"; (3) lore-summaries paragraph: "Implementation detail
+// goes in" → "Detail goes in"; (4) transfer-reasoning heading: "carry
+// implementation detail" → "carry the detail".
+const wantStaticSHA = "aa9bb5392d88825eca32cca804b6e3f621267d2373bfdc96ad9f366658051a60"
 
 func TestStaticInstructions_Embedded(t *testing.T) {
 	if staticInstructions == "" {


### PR DESCRIPTION
## Summary

Audit pass on `internal/mcp/instructions.md` to remove software-engineering-coded vocabulary from paragraphs where the convention is universal. Follows the pattern established in the QUEST-172 follow-up commit (which universalized the reasoning-surface paragraph from dev-only examples to project-type-agnostic examples).

## Paragraphs changed (4)

### 1. Rule 5 — quest report guidance
**Before:** `Be specific: commit hash, files, remaining issues.`
**After:** `Be specific: what changed, what remains, any blockers.`
**Rationale:** The `report` field on `quest_clear`/`quest_fulfill` is a universal field. "Commit hash" and "files" are software-specific nouns. A writer fulfilling a quest (e.g. "draft chapter 3") would have no commit or files to name. The universalized phrasing covers all project types without losing specificity.

### 2. Rule 11 — don't duplicate searchable content in lore
**Before:** `If grep can find it, it doesn't belong in lore. … Don't index files — inscribe knowledge.`
**After:** `If a search can find it, it doesn't belong in lore. … Don't index project content — inscribe knowledge.`
**Rationale:** `grep` is a Unix CLI tool name; the principle is about any search over any project content. "Don't index files" presupposes a software file layout. "Don't index project content" applies equally to a novel's chapter folder, a research bibliography, or a codebase.

### 3. Lore-summaries paragraph — depth guidance
**Before:** `Implementation detail goes in the quest acceptance that prompted the inscription — not in the lore summary.`
**After:** `Detail goes in the quest acceptance that prompted the inscription — not in the lore summary.`
**Rationale:** The concept is about summary depth vs. depth in quest acceptance — a universal writing/documentation convention. "Implementation detail" implies the detail is code or system design. "Detail" alone carries the same meaning without narrowing the audience.

### 4. Transfer-reasoning heading
**Before:** `Transfer reasoning lives in the lore summary; project artifacts carry implementation detail.`
**After:** `Transfer reasoning lives in the lore summary; project artifacts carry the detail.`
**Rationale:** Same as (3) — "implementation detail" is redundant and dev-coded here. The body of the paragraph already uses "carry deeper context, examples, and detail" which is universal.

## Paragraphs deliberately left as-is

- **Task-shaped examples** (lines 118–173): concrete, software-flavored subjects ("Fixed the race in retry budget accounting. Commit abc1234. Tests added in budget_test.go.") are intentional — examples benefit from a concrete domain, and the header "Task-shaped examples" already frames them as illustrative rather than prescriptive.
- **Rule 8 parallelism** ("no shared files and no deps"): `files` here refers to the quest metadata field `files=`, which is a guild abstraction applicable to any project type. Not dev-coded.
- **Canonical invocation examples** (lines 208–247): concrete parameter values are illustrative by design.
- **No sections were found that are genuinely software-specific in a way requiring preservation** — the audit found all four dev-coded phrases in universal-convention paragraphs.

## Contract hash

`wantStaticSHA` in `instructions_test.go` updated in the same commit with a comment documenting this QUEST-190 audit pass.

## Test plan

- [x] `go test ./internal/mcp/ -run TestStaticInstructions_ContractHash` passes with new hash
- [x] `make check` passes (fmt + vet + lint + sqlcheck + test-race)