### PR TITLE
fix(lore): make echoes git-aware checks independent of process cwd

### DIFF
--- a/internal/lore/echoes.go
+++ b/internal/lore/echoes.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -75,17 +76,49 @@ func echoReason(ctx context.Context, e *Entry, now time.Time, gitAware bool) str
 	return ""
 }
 
-// gitFileLastModified shells out to `git log -1 --format=%aI -- <path>`
+// gitFileLastModifiedFn is the seam for the git-aware staleness check.
+// Tests replace it to exercise the logic without a real git repo or a
+// specific process CWD.
+var gitFileLastModifiedFn = defaultGitFileLastModified
+
+// gitFileLastModified is the internal call site; it delegates to the
+// injectable seam so tests can substitute behaviour.
+func gitFileLastModified(ctx context.Context, path string) time.Time {
+	return gitFileLastModifiedFn(ctx, path)
+}
+
+// defaultGitFileLastModified shells out to `git log -1 --format=%aI -- <path>`
 // and returns the last-modified timestamp parsed to a time.Time.
 // Returns the zero time when git is missing, the file is not tracked,
 // or any error occurs — best-effort.
-func gitFileLastModified(ctx context.Context, path string) time.Time {
+//
+// The command is run with its working directory set to the directory that
+// contains the file, not the process CWD. This ensures the correct
+// repository context is used when guild is launched from outside the
+// target project's directory tree (e.g. MCP sessions, project overrides).
+func defaultGitFileLastModified(ctx context.Context, path string) time.Time {
 	// Bound the command with a 5-second timeout so a stuck git
 	// doesn't hang the lore read.
 	cmdCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
+
+	// Derive the repository root from the file's own directory so the
+	// query is never sensitive to the guild process's ambient CWD.
+	dir := filepath.Dir(path)
 	//nolint:gosec // arguments are hard-coded + file path from DB
-	out, err := exec.CommandContext(cmdCtx, "git", "log", "-1", "--format=%aI", "--", path).Output()
+	repoRootCmd := exec.CommandContext(cmdCtx, "git", "rev-parse", "--show-toplevel")
+	repoRootCmd.Dir = dir
+	repoRootOut, err := repoRootCmd.Output()
+	if err != nil {
+		// git missing, not a repo, or dir doesn't exist — degrade quietly.
+		return time.Time{}
+	}
+	repoRoot := strings.TrimSpace(string(repoRootOut))
+
+	//nolint:gosec // arguments are hard-coded + file path from DB
+	cmd := exec.CommandContext(cmdCtx, "git", "log", "-1", "--format=%aI", "--", path)
+	cmd.Dir = repoRoot
+	out, err := cmd.Output()
 	if err != nil {
 		return time.Time{}
 	}

--- a/internal/lore/echoes_test.go
+++ b/internal/lore/echoes_test.go
@@ -2,9 +2,23 @@ package lore
 
 import (
 	"context"
+	"os/exec"
 	"testing"
 	"time"
 )
+
+// execLookPath is a thin wrapper around exec.LookPath so tests can detect
+// whether git is available without importing os/exec at the call site.
+func execLookPath(name string) (string, error) { return exec.LookPath(name) }
+
+// swapGitFileLastModifiedFn replaces the package-level seam and returns a
+// restore function. Tests call t.Cleanup(restore) to ensure the original
+// is always put back.
+func swapGitFileLastModifiedFn(fn func(context.Context, string) time.Time) func() {
+	prev := gitFileLastModifiedFn
+	gitFileLastModifiedFn = fn
+	return func() { gitFileLastModifiedFn = prev }
+}
 
 func TestEchoes_ProjectRequired(t *testing.T) {
 	ctx := context.Background()
@@ -115,5 +129,147 @@ func TestEchoes_GitAwareSkippedWhenFilePathEmpty(t *testing.T) {
 	}
 	if len(stale) != 0 {
 		t.Fatalf("expected 0 stale; got %d", len(stale))
+	}
+}
+
+// TestEchoes_GitAwareDetectsModifiedFile verifies that when the injected
+// gitFileLastModifiedFn reports a modification time after the entry's
+// created_at, the entry is flagged — regardless of the process CWD.
+func TestEchoes_GitAwareDetectsModifiedFile(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	_, err := db.ExecContext(ctx, `INSERT OR IGNORE INTO projects (id, path) VALUES ('p','/tmp/p')`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	entryCreated := time.Now().UTC().AddDate(0, 0, -10)
+	fileModified := entryCreated.Add(24 * time.Hour) // file changed 1 day after the entry
+
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO entries (project_id, topic, kind, title, summary, status, file_path, created_at, updated_at)
+		 VALUES ('p','t','research','tracked file entry','summary','current','/some/repo/file.go',?,?)`,
+		entryCreated.Format(time.RFC3339), entryCreated.Format(time.RFC3339))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Inject a seam that reports the file was modified after the entry was
+	// created. The seam is called with the path from the DB; it must not
+	// care about or depend on the process CWD.
+	t.Cleanup(swapGitFileLastModifiedFn(func(_ context.Context, path string) time.Time {
+		if path == "/some/repo/file.go" {
+			return fileModified
+		}
+		return time.Time{}
+	}))
+
+	stale, err := Echoes(ctx, db, "p", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stale) != 1 {
+		t.Fatalf("want 1 stale entry; got %d: %+v", len(stale), stale)
+	}
+	if stale[0].Entry.Title != "tracked file entry" {
+		t.Fatalf("wrong entry flagged: %q", stale[0].Entry.Title)
+	}
+	if stale[0].Reason != "file modified after entry was created" {
+		t.Fatalf("unexpected reason: %q", stale[0].Reason)
+	}
+}
+
+// TestEchoes_GitAwareNotFlaggedWhenFileUnmodified verifies that an entry
+// is not flagged when the injected fn reports the file's last-modified
+// time is before (or equal to) the entry's created_at.
+func TestEchoes_GitAwareNotFlaggedWhenFileUnmodified(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	_, err := db.ExecContext(ctx, `INSERT OR IGNORE INTO projects (id, path) VALUES ('p','/tmp/p')`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	entryCreated := time.Now().UTC().AddDate(0, 0, -10)
+
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO entries (project_id, topic, kind, title, summary, status, file_path, created_at, updated_at)
+		 VALUES ('p','t','research','stable file entry','summary','current','/some/repo/stable.go',?,?)`,
+		entryCreated.Format(time.RFC3339), entryCreated.Format(time.RFC3339))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// File was last modified before the entry was written.
+	fileModified := entryCreated.Add(-24 * time.Hour)
+	t.Cleanup(swapGitFileLastModifiedFn(func(_ context.Context, _ string) time.Time {
+		return fileModified
+	}))
+
+	stale, err := Echoes(ctx, db, "p", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stale) != 0 {
+		t.Fatalf("expected 0 stale entries; got %d: %+v", len(stale), stale)
+	}
+}
+
+// TestEchoes_GitAwareDegradesMissingGit verifies that when the injected fn
+// returns the zero time (simulating missing git, non-repo path, or
+// untracked file), the entry is NOT flagged and no error is returned.
+func TestEchoes_GitAwareDegradesMissingGit(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	_, err := db.ExecContext(ctx, `INSERT OR IGNORE INTO projects (id, path) VALUES ('p','/tmp/p')`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	entryCreated := time.Now().UTC().AddDate(0, 0, -10)
+
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO entries (project_id, topic, kind, title, summary, status, file_path, created_at, updated_at)
+		 VALUES ('p','t','research','non-repo file','summary','current','/not/a/repo/file.go',?,?)`,
+		entryCreated.Format(time.RFC3339), entryCreated.Format(time.RFC3339))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate git missing / non-repo / untracked — fn returns zero time.
+	t.Cleanup(swapGitFileLastModifiedFn(func(_ context.Context, _ string) time.Time {
+		return time.Time{}
+	}))
+
+	stale, err := Echoes(ctx, db, "p", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Zero time is treated as "no git info" — entry must NOT be flagged.
+	if len(stale) != 0 {
+		t.Fatalf("expected 0 stale entries when git unavailable; got %d: %+v", len(stale), stale)
+	}
+}
+
+// TestDefaultGitFileLastModified_OutsideRepo exercises the real
+// defaultGitFileLastModified against a path that genuinely lives in a
+// temporary directory that is NOT inside any git repository. It must
+// return the zero time rather than panic or error.
+func TestDefaultGitFileLastModified_OutsideRepo(t *testing.T) {
+	if _, err := execLookPath("git"); err != nil {
+		t.Skip("git not available on PATH")
+	}
+	ctx := context.Background()
+	// t.TempDir() is outside any repo — git rev-parse will fail.
+	path := t.TempDir() + "/nonexistent.go"
+	got := defaultGitFileLastModified(ctx, path)
+	if !got.IsZero() {
+		t.Fatalf("expected zero time for non-repo path; got %v", got)
 	}
 }


### PR DESCRIPTION
## Summary

- **Root cause**: `gitFileLastModified` called `git log` without setting a working directory, so it ran in the guild process's ambient CWD. When guild is launched outside the target repository (MCP sessions, `--project` overrides), `git log` found no matching history and silently returned zero — masking the modified-file signal the feature exists to surface.
- **Fix**: derive the repository root from the file path itself (`git rev-parse --show-toplevel` with `cmd.Dir` set to the file's containing directory), then run `git log` with `cmd.Dir` set to that root. Process CWD no longer influences the result.
- **Seam**: introduce `gitFileLastModifiedFn` as an injectable package-level variable, matching the `gitToplevelFn` pattern in `init.go`, so tests can exercise the logic without a real git repo.

## Degradation paths

All three degrade quietly (return zero time, entry not flagged):
- `git` binary not on PATH
- File path not inside any git repository
- File exists in a repo but is untracked (git log returns empty output)

## Test plan

- `TestEchoes_GitAwareDetectsModifiedFile` — injected fn reports file modified after entry created → entry flagged
- `TestEchoes_GitAwareNotFlaggedWhenFileUnmodified` — file modified before entry created → not flagged
- `TestEchoes_GitAwareDegradesMissingGit` — fn returns zero time → not flagged, no error
- `TestDefaultGitFileLastModified_OutsideRepo` — real subprocess against a `t.TempDir()` path outside any repo → zero time
- All existing echo tests continue to pass
- `make check` fully green (fmt + vet + lint + sqlcheck + test-race)

Fixes mathomhaus/guild#24