### PR TITLE
fix(quest): recompute blocked status when dependencies clear

### DIFF
--- a/internal/quest/update.go
+++ b/internal/quest/update.go
@@ -220,27 +220,17 @@ func Update(ctx context.Context, db *sql.DB, projectID, taskID string, params Up
 		}
 	}
 
-	// Auto-block on new deps.
-	depIDsForBlockCheck := append([]string{}, newDepIDs...)
-	depIDsForBlockCheck = append(depIDsForBlockCheck, replaceDepIDs...)
-	if len(depIDsForBlockCheck) > 0 && curStatus != StatusDone && curStatus != StatusBlocked {
-		allDone, err := depsAllDoneTx(ctx, tx, projectID, depIDsForBlockCheck)
-		if err != nil {
+	// Recompute blockedness symmetrically when this call touched deps.
+	// The auto-block half was original; the auto-unblock half fixes
+	// QUEST-147 — clearing or replacing deps on a blocked quest used to
+	// leave status='blocked' even after every dep was satisfied, stranding
+	// the quest and tempting agents to raw-SQL unstick it.
+	depsTouched := len(newDepIDs) > 0 ||
+		len(params.ReplaceDependsOn) > 0 ||
+		params.ClearDependsOn
+	if depsTouched {
+		if err := recomputeBlockedness(ctx, tx, projectID, taskID, curStatus, agent, now); err != nil {
 			return nil, err
-		}
-		if !allDone {
-			if _, err := tx.ExecContext(ctx,
-				`UPDATE task_status
-				 SET status = 'blocked', updated_at = ?
-				 WHERE project_id = ? AND task_id = ?`,
-				now, projectID, taskID,
-			); err != nil {
-				return nil, fmt.Errorf("quest: update: auto-block: %w", err)
-			}
-			if err := emitEvent(ctx, tx, projectID, taskID, "blocked", agent,
-				"blocked by: "+strings.Join(depIDsForBlockCheck, ", "), now); err != nil {
-				return nil, err
-			}
 		}
 	}
 
@@ -274,4 +264,63 @@ func Update(ctx context.Context, db *sql.DB, projectID, taskID string, params Up
 // variants diverge we'll split them, but today they're identical.
 func depsAllDoneTx(ctx context.Context, tx *sql.Tx, projectID string, depIDs []string) (bool, error) {
 	return depsAllDone(ctx, tx, projectID, depIDs)
+}
+
+// recomputeBlockedness flips taskID between 'blocked' and 'next' based
+// on the canonical depends_on set after Update's spec notes have been
+// written. Must be called AFTER the spec-note inserts so loadSpec
+// observes the resulting dep list (append+replace+clear already
+// applied).
+//
+// Transition table (curStatus → action):
+//
+//	next, in_progress → 'blocked' if any current dep is not done
+//	blocked           → 'next'    if every current dep is done (or none)
+//	done              → no-op (terminal)
+//
+// Only the status flip path that differs from the current state emits
+// an event — a no-op recompute is silent. The blocked→next direction
+// reuses EventUnblocked so pulse/scroll view the two unblock paths
+// (Fulfill cascade + Update recompute) consistently.
+//
+// Cascade note: this helper does NOT walk `blocks` edges. An Update
+// that unblocks B doesn't make B 'done', so no quest waiting on B's
+// completion changes state. Cascade-through-done is Fulfill's job.
+func recomputeBlockedness(ctx context.Context, tx *sql.Tx, projectID, taskID string, curStatus Status, agent, now string) error {
+	if curStatus == StatusDone {
+		return nil
+	}
+	spec, err := loadSpec(ctx, tx, projectID, taskID)
+	if err != nil {
+		return fmt.Errorf("quest: update: recompute deps: %w", err)
+	}
+	allDone, err := depsAllDoneTx(ctx, tx, projectID, spec.DependsOn)
+	if err != nil {
+		return err
+	}
+	switch {
+	case !allDone && curStatus != StatusBlocked:
+		if _, err := tx.ExecContext(ctx,
+			`UPDATE task_status
+			 SET status = 'blocked', updated_at = ?
+			 WHERE project_id = ? AND task_id = ?`,
+			now, projectID, taskID,
+		); err != nil {
+			return fmt.Errorf("quest: update: auto-block: %w", err)
+		}
+		return emitEvent(ctx, tx, projectID, taskID, "blocked", agent,
+			"blocked by: "+strings.Join(spec.DependsOn, ", "), now)
+	case allDone && curStatus == StatusBlocked:
+		if _, err := tx.ExecContext(ctx,
+			`UPDATE task_status
+			 SET status = 'next', updated_at = ?
+			 WHERE project_id = ? AND task_id = ? AND status = 'blocked'`,
+			now, projectID, taskID,
+		); err != nil {
+			return fmt.Errorf("quest: update: auto-unblock: %w", err)
+		}
+		return emitEvent(ctx, tx, projectID, taskID, EventUnblocked, agent,
+			"deps satisfied", now)
+	}
+	return nil
 }

--- a/internal/quest/update_test.go
+++ b/internal/quest/update_test.go
@@ -148,6 +148,121 @@ func TestUpdate_AutoBlockOnNewDep(t *testing.T) {
 	}
 }
 
+// TestUpdate_AutoUnblock_FulfillDepPath is the QUEST-147 fulfill-dep
+// regression: B is blocked via Update-added dep on A; when A is
+// fulfilled the cascade (not the Update recompute path) flips B.
+// This path was already covered by TestUpdate_AutoBlockOnNewDep; the
+// explicit assertion here guards the post-fix blocked→next transition
+// path reported by the `Update` recompute helper stays compatible with
+// the cascade helper (both use EventUnblocked).
+func TestUpdate_AutoUnblock_FulfillDepPath(t *testing.T) {
+	db, pid := newTestDB(t)
+	ctx := context.Background()
+	a := mustPost(t, db, pid, PostParams{Subject: "A"})
+	b := mustPost(t, db, pid, PostParams{Subject: "B"})
+
+	if _, err := Update(ctx, db, pid, b.ID, UpdateParams{DependsOn: []string{a.ID}}); err != nil {
+		t.Fatalf("Update add dep: %v", err)
+	}
+	if s := mustStatus(t, db, pid, b.ID); s != StatusBlocked {
+		t.Fatalf("B status = %s, want blocked before A fulfilled", s)
+	}
+
+	res, err := Fulfill(ctx, db, pid, a.ID, "done-reason")
+	if err != nil {
+		t.Fatalf("Fulfill A: %v", err)
+	}
+	if len(res.Unblocked) != 1 || res.Unblocked[0].ID != b.ID {
+		t.Fatalf("Fulfill unblocked = %v, want [%s]", idsOf(res.Unblocked), b.ID)
+	}
+	if s := mustStatus(t, db, pid, b.ID); s != StatusNext {
+		t.Errorf("B status = %s, want next after A fulfilled", s)
+	}
+}
+
+// TestUpdate_AutoUnblock_ClearDependsOnPath is the QUEST-147 core
+// regression: an agent posts B depending on A, realizes the dep was
+// wrong, and clears it. Before the fix, B stayed 'blocked' even with
+// zero deps on the canonical list — the agent's only recourse was
+// raw-SQL surgery, violating the no-SQL-bypass oath.
+func TestUpdate_AutoUnblock_ClearDependsOnPath(t *testing.T) {
+	db, pid := newTestDB(t)
+	ctx := context.Background()
+	a := mustPost(t, db, pid, PostParams{Subject: "A"})
+	b := mustPost(t, db, pid, PostParams{Subject: "B"})
+
+	if _, err := Update(ctx, db, pid, b.ID, UpdateParams{DependsOn: []string{a.ID}}); err != nil {
+		t.Fatalf("Update add dep: %v", err)
+	}
+	if s := mustStatus(t, db, pid, b.ID); s != StatusBlocked {
+		t.Fatalf("B status = %s, want blocked before clear", s)
+	}
+
+	// Clear B's deps while A is still not done — B must still unblock
+	// because the canonical dep list is now empty.
+	if _, err := Update(ctx, db, pid, b.ID, UpdateParams{ClearDependsOn: true}); err != nil {
+		t.Fatalf("Update clear deps: %v", err)
+	}
+	if s := mustStatus(t, db, pid, b.ID); s != StatusNext {
+		t.Errorf("B status = %s, want next after clearing deps (was blocked, now 0 deps)", s)
+	}
+	reloaded := mustLoad(t, db, pid, b.ID)
+	if len(reloaded.DependsOn) != 0 {
+		t.Errorf("B deps = %v, want empty after ClearDependsOn", reloaded.DependsOn)
+	}
+}
+
+// TestUpdate_AutoUnblock_ReplaceDependsOnPath exercises the replace
+// form of the same fix: swapping a not-done dep set for a done-or-empty
+// dep set must flip blocked→next. Uses a 3-quest graph so the test also
+// asserts that cascade-through-multiple-deps is honored — when the new
+// dep set contains a not-done entry, B stays blocked.
+func TestUpdate_AutoUnblock_ReplaceDependsOnPath(t *testing.T) {
+	db, pid := newTestDB(t)
+	ctx := context.Background()
+	a := mustPost(t, db, pid, PostParams{Subject: "A"})
+	c := mustPost(t, db, pid, PostParams{Subject: "C"})
+	d := mustPost(t, db, pid, PostParams{Subject: "D"})
+	b := mustPost(t, db, pid, PostParams{Subject: "B"})
+
+	// B blocked on A.
+	if _, err := Update(ctx, db, pid, b.ID, UpdateParams{DependsOn: []string{a.ID}}); err != nil {
+		t.Fatalf("Update add dep A: %v", err)
+	}
+	if s := mustStatus(t, db, pid, b.ID); s != StatusBlocked {
+		t.Fatalf("B status = %s, want blocked", s)
+	}
+
+	// Fulfill C (done) but not D.
+	if _, err := Fulfill(ctx, db, pid, c.ID, ""); err != nil {
+		t.Fatalf("Fulfill C: %v", err)
+	}
+
+	// Replace deps with [C, D] — D is not done, so B must STAY blocked.
+	if _, err := Update(ctx, db, pid, b.ID, UpdateParams{
+		ReplaceDependsOn: []string{c.ID, d.ID},
+	}); err != nil {
+		t.Fatalf("Update replace deps [C,D]: %v", err)
+	}
+	if s := mustStatus(t, db, pid, b.ID); s != StatusBlocked {
+		t.Errorf("B status = %s, want blocked (D not done)", s)
+	}
+
+	// Replace deps with just [C] — C is done, so B must unblock.
+	if _, err := Update(ctx, db, pid, b.ID, UpdateParams{
+		ReplaceDependsOn: []string{c.ID},
+	}); err != nil {
+		t.Fatalf("Update replace deps [C]: %v", err)
+	}
+	if s := mustStatus(t, db, pid, b.ID); s != StatusNext {
+		t.Errorf("B status = %s, want next (replaced deps all done)", s)
+	}
+	reloaded := mustLoad(t, db, pid, b.ID)
+	if len(reloaded.DependsOn) != 1 || reloaded.DependsOn[0] != c.ID {
+		t.Errorf("B deps = %v, want [%s]", reloaded.DependsOn, c.ID)
+	}
+}
+
 func TestUpdate_ClearAcceptance(t *testing.T) {
 	db, pid := newTestDB(t)
 	q := mustPost(t, db, pid, PostParams{


### PR DESCRIPTION
## Summary

`quest_update` applied the block/unblock decision asymmetrically. Adding an unsatisfied dependency flipped a quest to `blocked`, but clearing, replacing, or fulfilling-out a dependency on an already-blocked quest never flipped it back. Agents posting sub-quests defensively with dependencies and then clearing them hit a dead-end where the canonical `depends_on` list was empty but `status = 'blocked'` stayed stuck — tempting a raw-SQL escape hatch against `~/.guild/quest.db` that violates the no-SQL-bypass contract.

## Fix

Factor the block/unblock decision into a `recomputeBlockedness` helper in `internal/quest/update.go`, invoked when `Update` touches deps via any of the three paths (append `DependsOn`, `ReplaceDependsOn`, `ClearDependsOn`). The helper reloads the canonical `DependsOn` via `loadSpec` after the spec notes are written — so append+replace+clear replay has already collapsed — and picks the transition:

| curStatus          | canonical deps         | action                                 |
| ------------------ | ---------------------- | -------------------------------------- |
| next, in_progress  | any dep not done       | flip to `blocked`, emit "blocked"      |
| blocked            | all deps done (or [])  | flip to `next`, emit `EventUnblocked`  |
| done               | (any)                  | no-op (terminal)                       |

Reuses `EventUnblocked` so `pulse`/`scroll` render the `Fulfill`-cascade and `Update`-recompute unblock paths identically. Does not walk `blocks` edges: `Update` doesn't mark anything done, so cascade-through-done remains `Fulfill`'s responsibility.

## Test plan

All three paths from the issue's test plan are covered in `internal/quest/update_test.go`:

- [x] `TestUpdate_AutoUnblock_FulfillDepPath` — B blocked via `Update`-added dep on A; `Fulfill(A)` unblocks B via cascade (existing path, now pinned with an explicit `StatusNext` assertion)
- [x] `TestUpdate_AutoUnblock_ClearDependsOnPath` — B blocked on not-done A; `Update(B, ClearDependsOn=true)` flips B to `next` with zero canonical deps (core regression)
- [x] `TestUpdate_AutoUnblock_ReplaceDependsOnPath` — B blocked on A; replace with `[C, D]` where D is not done → B stays blocked; replace with `[C]` (done) → B flips to `next` (also exercises stay-blocked when the new dep set still has an unsatisfied entry)
- [x] `make check` (fmt + vet + lint + sqlcheck + test-race) passes

Fixes mathomhaus/guild#19