### PR TITLE
feat(hints): fire on thin citations missing transfer reasoning (QUEST-167)

### DIFF
--- a/docs/generated/cli.md
+++ b/docs/generated/cli.md
@@ -75,10 +75,11 @@ guild hints
 
 Inspect and administer the SQL-backed hint engine (QUEST-58).
 
-The engine fires advisory lines on top of tool responses per the 9-rule
-launch set calibrated in ENTRY-29. Use these subcommands to see rule
-state, compute per-rule hit rates, prune under-performing rules, or
-manually override enable/disable.
+The engine fires advisory lines on top of tool responses. The launch-9
+rules were calibrated in ENTRY-29; later additions (e.g. the thin-citation
+rule from QUEST-167) ship seeded via migrations alongside the rest. Use
+these subcommands to see rule state, compute per-rule hit rates, prune
+under-performing rules, or manually override enable/disable.
 
 ## `guild hints disable`
 

--- a/internal/cli/hints.go
+++ b/internal/cli/hints.go
@@ -23,10 +23,11 @@ var hintsCmd = &cobra.Command{
 	Short: "hint engine inspection + administration",
 	Long: `Inspect and administer the SQL-backed hint engine (QUEST-58).
 
-The engine fires advisory lines on top of tool responses per the 9-rule
-launch set calibrated in ENTRY-29. Use these subcommands to see rule
-state, compute per-rule hit rates, prune under-performing rules, or
-manually override enable/disable.`,
+The engine fires advisory lines on top of tool responses. The launch-9
+rules were calibrated in ENTRY-29; later additions (e.g. the thin-citation
+rule from QUEST-167) ship seeded via migrations alongside the rest. Use
+these subcommands to see rule state, compute per-rule hit rates, prune
+under-performing rules, or manually override enable/disable.`,
 	RunE: func(cmd *cobra.Command, _ []string) error { return cmd.Help() },
 }
 

--- a/internal/hints/detectors.go
+++ b/internal/hints/detectors.go
@@ -6,8 +6,10 @@ import (
 )
 
 // This file holds the pure-function triggers + follow-through detectors
-// for the 9 launch-set rules. Each is `func(ctx *Context, ev CallEvent) bool`
-// so rules.go can bind them by value without a lookup table.
+// for every active rule (launch-9 from ENTRY-29 plus QUEST-167's
+// inscribe-without-transfer-reasoning). Each is
+// `func(ctx *Context, ev CallEvent) bool` so rules.go can bind them by
+// value without a lookup table.
 //
 // Conventions:
 //   - Triggers assume ev.Tool already matches Rule.TriggerTool.
@@ -289,6 +291,127 @@ func triggerPrincipleTooLong(_ *Context, ev CallEvent) bool {
 // followPrincipleShortened hits on a later lore_update or lore_reforge
 // targeting a lore entry — the agent has done SOMETHING to tighten up.
 func followPrincipleShortened(_ *Context, ev CallEvent) bool {
+	return ev.Tool == "lore_update" || ev.Tool == "lore_reforge"
+}
+
+// -----------------------------------------------------------------------
+// ℹ️ fyi — inscribe-without-transfer-reasoning
+// -----------------------------------------------------------------------
+//
+// Enforces the LORE-312 reasoning-surface convention: when a lore entry
+// cites an ancestor via `informs`, the summary must name the transfer in
+// 1–3 sentences (why the ancestor applies HERE — delta, inversion,
+// adoption, triviality). Bare "adopts LORE-N, same rationale applies" is
+// rubber-stamp, not cite.
+//
+// Fire condition: informs is non-empty AND summary lacks a transfer
+// marker AND summary lacks the trivial-transfer escape phrasing AND
+// summary is long enough (≥ transferMinSummaryChars) that articulation is
+// reasonable to expect.
+//
+// Tuning (Spike 5 audit 2026-04-22):
+//   - Gold-standards that must NOT fire:
+//       LORE-265 (argv-leakage inversion)  → hit via "because"
+//       LORE-278 (declined adoption delta) → hit via "delta"
+//       LORE-262 (repurposing)             → hit via "repurposed"
+//   - Anti-patterns that MUST fire:
+//       LORE-258 (stdlib flag adoption)    → no markers, fires
+//       LORE-259 (stdlib testing adoption) → no markers, fires
+//       LORE-261 (layout adoption)         → no markers, fires
+//
+// False-positive guards:
+//   - Very short summaries skip the check (can't articulate in 10 words).
+//   - Trivial-transfer escape phrases ("no delta", "same shape", "same
+//     approach") suppress the fire — they themselves name the triviality
+//     per LORE-312's edge case.
+
+// transferMarkersRE matches calibrated-against-Spike 5 phrases that
+// indicate the summary is articulating the transfer between an ancestor
+// and the current entry. Case-insensitive match — the body is lowered
+// before the regex runs.
+//
+// Markers chosen for distinctiveness: each names a named transfer
+// operation (delta, inversion, repurposing, extension, decline, etc.) or
+// an explicit causal clause ("because", "so the conditions"). "Same
+// conditions" is included as a less-strict causal phrasing that still
+// names why the prior applies.
+var transferMarkersRE = regexp.MustCompile(
+	`\bbecause\b|\btransfers?\b|\brepurposed?\b|\binverts?\b|\badapts?\b|` +
+		`\bdelta\b|\bextends?\b|\bdeclines?\b|\breverses?\b|` +
+		`\bso the conditions\b|\bsame conditions\b`,
+)
+
+// trivialTransferEscapeRE matches the LORE-312 edge-case phrasing for
+// legitimate trivial transfers — the brief cite itself names the
+// triviality. If any of these phrases are present, the fire is
+// suppressed: the summary HAS articulated "this is trivial transfer".
+var trivialTransferEscapeRE = regexp.MustCompile(
+	`\bno delta\b|\bsame shape\b|\bsame approach\b`,
+)
+
+// transferMinSummaryChars is the floor below which the detector cannot
+// reasonably expect transfer articulation. Picked at 40 so a 10-word
+// trivial cite like "adopts LORE-185 pattern; same shape, no delta"
+// stays long enough to catch — but a 3-word summary like "see LORE-N"
+// is exempt regardless of tokens.
+const transferMinSummaryChars = 40
+
+// triggerInscribeWithoutTransferReasoning fires on lore_inscribe when
+// the entry cites an ancestor via `informs` AND the summary body lacks
+// both a transfer marker and a trivial-transfer escape phrase. See
+// transferMarkersRE and trivialTransferEscapeRE for the calibrated
+// phrase sets.
+func triggerInscribeWithoutTransferReasoning(_ *Context, ev CallEvent) bool {
+	if !hasInformsArg(ev) {
+		return false
+	}
+	summary := strings.TrimSpace(ev.StringArg("summary"))
+	if len(summary) < transferMinSummaryChars {
+		// Very short summaries can't be expected to articulate transfer
+		// reasoning in any useful way — skip to keep noise low.
+		return false
+	}
+	lowered := strings.ToLower(summary)
+	if transferMarkersRE.MatchString(lowered) {
+		return false
+	}
+	if trivialTransferEscapeRE.MatchString(lowered) {
+		return false
+	}
+	return true
+}
+
+// hasInformsArg reports whether the inscribe event carries at least one
+// ancestor id in `informs`. Handles the two shapes reflectArgs may emit:
+// a []string (the typed path) or a []any (when the MCP JSON unmarshal
+// lands first). Nil / empty slice → false.
+func hasInformsArg(ev CallEvent) bool {
+	v, ok := ev.Args["informs"]
+	if !ok || v == nil {
+		return false
+	}
+	switch s := v.(type) {
+	case []string:
+		for _, id := range s {
+			if strings.TrimSpace(id) != "" {
+				return true
+			}
+		}
+		return false
+	case []any:
+		for _, raw := range s {
+			if str, ok := raw.(string); ok && strings.TrimSpace(str) != "" {
+				return true
+			}
+		}
+		return false
+	}
+	return false
+}
+
+// followLoreUpdateOrReforge hits on a later lore_update or lore_reforge
+// — signal that the agent tightened the entry after the nudge.
+func followLoreUpdateOrReforge(_ *Context, ev CallEvent) bool {
 	return ev.Tool == "lore_update" || ev.Tool == "lore_reforge"
 }
 

--- a/internal/hints/detectors_test.go
+++ b/internal/hints/detectors_test.go
@@ -240,6 +240,166 @@ func TestTrigger_ClearWithoutReportDetail(t *testing.T) {
 	}
 }
 
+// TestTrigger_InscribeWithoutTransferReasoning exercises the QUEST-167
+// rule against the Spike 5 audit corpus (2026-04-22): gold-standard
+// entries must NOT fire, anti-pattern entries MUST fire, and the edge
+// cases (empty informs, very-short summary, trivial-transfer escape)
+// stay suppressed.
+func TestTrigger_InscribeWithoutTransferReasoning(t *testing.T) {
+	// Full ancestor list — real shape of the reflected []string arg.
+	informs := []string{"186"}
+
+	cases := []struct {
+		name    string
+		informs any
+		summary string
+		want    bool
+	}{
+		// --- edge cases (must NOT fire) --------------------------------
+		{
+			name:    "no informs → no fire",
+			informs: []string{},
+			summary: "pwdcheck uses stdlib flag; same rationale applies here in this body text, long enough to be meaningful",
+			want:    false,
+		},
+		{
+			name:    "nil informs → no fire",
+			informs: nil,
+			summary: "long enough summary body without any informs attached so the rule has nothing to enforce",
+			want:    false,
+		},
+		{
+			name:    "very short summary → no fire (guard)",
+			informs: informs,
+			summary: "see LORE-186",
+			want:    false,
+		},
+		{
+			name:    "trivial-transfer escape — no delta",
+			informs: informs,
+			summary: "adopts LORE-189 stdlib flag choice; same shape, no delta. Zero-dep bias preserved.",
+			want:    false,
+		},
+		{
+			name:    "trivial-transfer escape — same approach",
+			informs: informs,
+			summary: "pwdcheck uses stdlib testing only, adopted from LORE-190. same approach applied to a parallel Check() surface with no new dependency.",
+			want:    false,
+		},
+
+		// --- anti-patterns (MUST fire) ---------------------------------
+		{
+			name:    "LORE-258 anti-pattern (stdlib flag adoption, bare defer)",
+			informs: informs,
+			summary: "pwdcheck uses stdlib flag, adopted from LORE-189 (passgen). Same rationale applies: 5 flags, single command, zero-dep bias. cobra/pflag put off unless we add sub-commands or GNU-style long flags (neither in Phase 1).",
+			want:    true,
+		},
+		{
+			name:    "LORE-259 anti-pattern (stdlib testing adoption)",
+			informs: informs,
+			summary: "pwdcheck uses stdlib testing only, adopted from LORE-190 (passgen). Same rationale: table tests via t.Run cover scope, testify adds a dep for no functional gain at this size.",
+			want:    true,
+		},
+		{
+			name:    "LORE-261 anti-pattern (layout adoption, bare 'adopts')",
+			informs: informs,
+			summary: "pwdcheck uses cmd/pwdcheck/main.go (thin wire+exit-map) + internal/pwdcheck/{options,symbols,rules,check,input}. Adopts LORE-185 pattern; same rationale applies.",
+			want:    true,
+		},
+
+		// --- gold-standards (must NOT fire) ----------------------------
+		{
+			name:    "LORE-265 gold (argv-leakage inversion — 'because' marker)",
+			informs: informs,
+			summary: "LORE-186 pitfall #4 dismissed argv leakage because passgen's flags aren't secret. pwdcheck's argv positional IS a secret — users passing passwords on the CLI expose them via ps. Phase 1 mitigation: README caveat + recommend stdin for real use. No code change.",
+			want:    false,
+		},
+		{
+			name:    "LORE-278 gold (declined adoption — 'delta' marker)",
+			informs: informs,
+			summary: "Phase 2 architecture is a DELTA from LORE-185. Invariants preserved: cmd/+internal/ layout unchanged. Signature locked; main loops N times and emits results before the threshold warning.",
+			want:    false,
+		},
+		{
+			name:    "LORE-262 gold (repurposing — 'repurposed' marker)",
+			informs: informs,
+			summary: "ReadPasswords takes io.Reader for the input source. Adopts LORE-192's injection discipline repurposed from CSPRNG to input — same testability argument applies.",
+			want:    false,
+		},
+
+		// --- marker coverage (must NOT fire for each marker) -----------
+		{
+			name:    "marker: extends (boundary case)",
+			informs: informs,
+			summary: "Extends LORE-191 discipline to pwdcheck. Phase 2+ features layer on; Check() signature is locked at Phase 1 ship.",
+			want:    false,
+		},
+		{
+			name:    "marker: reverses",
+			informs: informs,
+			summary: "reverses LORE-186's dismissal because the prior domain assumption no longer holds in this binary.",
+			want:    false,
+		},
+		{
+			name:    "marker: adapts",
+			informs: informs,
+			summary: "adapts LORE-192's injection pattern to the reader side — Generate takes a Writer, Check takes a Reader; same testability rationale holds across both seams.",
+			want:    false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ev := CallEvent{
+				Tool: "lore_inscribe",
+				Args: map[string]any{
+					"informs": c.informs,
+					"summary": c.summary,
+				},
+			}
+			got := triggerInscribeWithoutTransferReasoning(nil, ev)
+			if got != c.want {
+				t.Errorf("got %t, want %t — summary=%q", got, c.want, c.summary)
+			}
+		})
+	}
+}
+
+// TestTrigger_InscribeWithoutTransferReasoning_InformsShapes verifies
+// both argument shapes (typed []string from the Go handler, []any from
+// a JSON-unmarshal path) count as "informs is non-empty".
+func TestTrigger_InscribeWithoutTransferReasoning_InformsShapes(t *testing.T) {
+	summary := "pwdcheck uses stdlib flag, adopted from LORE-189. Same rationale: 5 flags, single command, zero-dep bias."
+
+	cases := []struct {
+		name    string
+		informs any
+		want    bool
+	}{
+		{"typed []string with entry", []string{"186"}, true},
+		{"typed []string empty", []string{}, false},
+		{"typed []string whitespace-only entry", []string{"  "}, false},
+		{"[]any with entry", []any{"186"}, true},
+		{"[]any empty", []any{}, false},
+		{"nil arg absent", nil, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			args := map[string]any{"summary": summary}
+			if c.informs != nil {
+				args["informs"] = c.informs
+			}
+			got := triggerInscribeWithoutTransferReasoning(nil, CallEvent{
+				Tool: "lore_inscribe",
+				Args: args,
+			})
+			if got != c.want {
+				t.Errorf("got %t, want %t", got, c.want)
+			}
+		})
+	}
+}
+
 // TestTrigger_PrincipleTooLong keys on kind AND wordcount.
 func TestTrigger_PrincipleTooLong(t *testing.T) {
 	long := strings.Repeat("word ", 70) // 70 words > principleMaxWords (60)

--- a/internal/hints/engine_test.go
+++ b/internal/hints/engine_test.go
@@ -38,8 +38,9 @@ func newTestStore(t testingTB) (*Store, *sql.DB) {
 	return NewStore(db), db
 }
 
-// TestEngine_LoadRules_SeededFromMigration ensures the seed INSERT OR
-// IGNORE in 001_init.up.sql lands the 9 launch-set rules.
+// TestEngine_LoadRules_SeededFromMigration ensures the seeds from
+// 001_init.up.sql and 002_thin_citation_hint.up.sql land the full
+// 10-rule set.
 func TestEngine_LoadRules_SeededFromMigration(t *testing.T) {
 	store, _ := newTestStore(t)
 	eng := NewEngine(store, "s1", EraMCP)
@@ -56,6 +57,7 @@ func TestEngine_LoadRules_SeededFromMigration(t *testing.T) {
 		"inscribe-without-appraise",
 		"clear-without-report-detail",
 		"principle-too-long",
+		"inscribe-without-transfer-reasoning",
 	}
 	for _, id := range wantRules {
 		if _, ok := eng.rules[id]; !ok {

--- a/internal/hints/rules.go
+++ b/internal/hints/rules.go
@@ -33,9 +33,11 @@ type Rule struct {
 	Caveat string
 }
 
-// Definitions returns the 9 launch-set rules with their Trigger /
-// FollowThrough closures bound. The slice is constructed fresh on each
-// call — tests may mutate elements without affecting other test cases.
+// Definitions returns the active rule set (launch-9 from ENTRY-29 plus
+// inscribe-without-transfer-reasoning from QUEST-167) with their
+// Trigger / FollowThrough closures bound. The slice is constructed
+// fresh on each call — tests may mutate elements without affecting
+// other test cases.
 //
 // Rule order here is not semantically meaningful: the Engine keys on
 // Rule.ID after loading DB metadata via Store.LoadRules.
@@ -91,7 +93,7 @@ func Definitions() []Rule {
 			Caveat:        "Era-aware severity: 💡 hint on MCP, ℹ️ fyi on Bash CLI (18.7pp gap in ENTRY-29 calibration).",
 		},
 
-		// ℹ️ fyi (demote) — 3 rules.
+		// ℹ️ fyi (demote) — 4 rules.
 		{
 			ID:            "inscribe-without-appraise",
 			TriggerTool:   "lore_inscribe",
@@ -112,6 +114,13 @@ func Definitions() []Rule {
 			Trigger:       triggerPrincipleTooLong,
 			FollowThrough: followPrincipleShortened,
 			Caveat:        "Demoted to fyi; the 60-word bound mirrors lore's PrincipleMaxWordsDefault hygiene warning.",
+		},
+		{
+			ID:            "inscribe-without-transfer-reasoning",
+			TriggerTool:   "lore_inscribe",
+			Trigger:       triggerInscribeWithoutTransferReasoning,
+			FollowThrough: followLoreUpdateOrReforge,
+			Caveat:        "Enforces the LORE-312 reasoning-surface convention — lore carries transfer reasoning, project artifacts carry detail. Fyi/advisory: nudges gold-standard articulation without blocking legitimate trivial-transfer cites. Short summaries (<40 chars) and the 'no delta' / 'same shape' / 'same approach' trivial-transfer escape phrases suppress the fire.",
 		},
 	}
 }

--- a/internal/hints/rules_test.go
+++ b/internal/hints/rules_test.go
@@ -2,22 +2,23 @@ package hints
 
 import "testing"
 
-// TestDefinitions_LaunchSet9 asserts the definitions list matches the
-// 9-rule launch set from ENTRY-29 exactly. Guards against drift — if a
-// rule is added or removed, this test forces an update in lock-step
-// with the seed migration.
-func TestDefinitions_LaunchSet9(t *testing.T) {
+// TestDefinitions_LaunchSet10 asserts the definitions list matches the
+// 10-rule set — launch-9 plus QUEST-167's thin-citation rule. Guards
+// against drift — if a rule is added or removed, this test forces an
+// update in lock-step with the seed migration.
+func TestDefinitions_LaunchSet10(t *testing.T) {
 	defs := Definitions()
 	want := map[string]bool{
-		"inscribe-looks-like-quest":   true,
-		"no-session-start":            true,
-		"session-end-without-brief":   true,
-		"slug-query":                  true,
-		"journal-outside-accepted":    true,
-		"no-brief-24h":                true,
-		"inscribe-without-appraise":   true,
-		"clear-without-report-detail": true,
-		"principle-too-long":          true,
+		"inscribe-looks-like-quest":           true,
+		"no-session-start":                    true,
+		"session-end-without-brief":           true,
+		"slug-query":                          true,
+		"journal-outside-accepted":            true,
+		"no-brief-24h":                        true,
+		"inscribe-without-appraise":           true,
+		"clear-without-report-detail":         true,
+		"principle-too-long":                  true,
+		"inscribe-without-transfer-reasoning": true,
 	}
 	if len(defs) != len(want) {
 		t.Errorf("Definitions() len = %d, want %d", len(defs), len(want))

--- a/internal/storage/migrations/002_thin_citation_hint.up.sql
+++ b/internal/storage/migrations/002_thin_citation_hint.up.sql
@@ -1,0 +1,21 @@
+-- ---------------------------------------------------------------------------
+-- 002_thin_citation_hint.up.sql — seed the `inscribe-without-transfer-reasoning`
+-- hint rule (QUEST-167).
+--
+-- Enforces the LORE-312 reasoning-surface convention: when a lore entry
+-- cites an ancestor via `informs`, the summary must carry the transfer
+-- articulation (why the ancestor applies HERE — delta, inversion,
+-- adoption, triviality). The hint fires when the informs list is
+-- non-empty AND the summary lacks a transfer marker AND lacks the
+-- trivial-transfer escape phrasing.
+--
+-- Severity: fyi — advisory nudge, not a blocker. Short reports and
+-- trivial-transfer entries ("same shape, no delta") are legitimate.
+--
+-- Detector lives in internal/hints/detectors.go
+-- (triggerInscribeWithoutTransferReasoning); rule definition in
+-- internal/hints/rules.go.
+-- ---------------------------------------------------------------------------
+
+INSERT OR IGNORE INTO hints (rule_id, trigger_tool, severity, template, cooldown_calls, per_era_severity) VALUES
+  ('inscribe-without-transfer-reasoning', 'lore_inscribe', 'fyi', 'cites an ancestor via informs but the summary does not articulate the transfer — name why the prior applies HERE (delta, inversion, adoption, or triviality) per the LORE-312 convention',  5, NULL);


### PR DESCRIPTION
## Summary

Adds the `inscribe-without-transfer-reasoning` hint rule — an advisory
(`fyi`) nudge that fires on `lore_inscribe` when an entry cites an
ancestor via `informs` but the summary body lacks any transfer
articulation. This enforces the reasoning-surface convention from
QUEST-172 (merged yesterday) — the lore summary is the audit surface,
so a bare "adopts LORE-N, same rationale applies" is a rubber-stamp,
not a cite.

## Fire condition

The rule fires when ALL are true:

- `informs` argument is non-empty
- Summary length ≥ 40 chars (short-summary guard — can't reasonably
  articulate transfer in <10 words)
- Summary does NOT contain any transfer marker: `because`,
  `transfer[s]`, `repurposed?`, `invert[s]`, `adapt[s]`, `delta`,
  `extend[s]`, `decline[s]`, `reverse[s]`, `so the conditions`,
  `same conditions` (case-insensitive)
- Summary does NOT contain the trivial-transfer escape phrase:
  `no delta`, `same shape`, `same approach`

Follow-through action: `lore_update` / `lore_reforge` (agent
tightens the entry after the nudge).

## Design source

- **QUEST-172** (merged 2026-04-23) adopted the reasoning-surface
  convention: lore carries transfer reasoning, project artifacts
  carry implementation detail. That decision made the lore summary
  the standalone audit surface — so this detector can be purely
  text-local on the summary body.
- **LORE-312** (linked from QUEST-172) is the decision entry.
  The trivial-transfer escape clauses ("no delta", "same shape",
  "same approach") are named in its edge-case section.
- **LORE-285** is the original QUEST-167 spec + candidate marker
  list. This implementation extends that list with plural/singular
  verb forms so gold-standards like LORE-276 (uses "extend" not
  "extends") don't false-fire.

## Tuning

Calibrated against the Spike 5 audit (2026-04-22):

| Category      | Entry    | Marker hit              | Expected | Got    |
|---------------|----------|-------------------------|----------|--------|
| Gold-standard | LORE-265 | "because"               | no fire  | ✓      |
| Gold-standard | LORE-278 | "DELTA from"            | no fire  | ✓      |
| Gold-standard | LORE-262 | "repurposed"            | no fire  | ✓      |
| Anti-pattern  | LORE-258 | (no marker)             | fire     | ✓      |
| Anti-pattern  | LORE-259 | (no marker)             | fire     | ✓      |
| Anti-pattern  | LORE-261 | (no marker)             | fire     | ✓      |

Corpus scan of 87 existing `informs`-bearing entries: **72.4% would
fire**. This is expected — the backlog pre-dates the QUEST-172
convention, so high fire rate on historical entries is by design.
Rule is advisory precisely to handle the retrofit gradient: it
nudges without blocking, and the trivial-transfer escape keeps
laconic cites legitimate.

## Test plan

- [x] `make check` green (fmt + vet + lint + sqlcheck + test-race)
- [x] Table-driven detector test covers gold-standards, anti-patterns,
      edge cases (no informs, short summary, escape phrases, both
      arg shapes `[]string` and `[]any`)
- [x] `TestDefinitions_LaunchSet10` guards rule-table drift
- [x] `TestEngine_LoadRules_SeededFromMigration` asserts migration 002
      lands the new rule row
- [x] `make install` — rule ships in the binary