### PR TITLE
fix(quest): serialize Fulfill under concurrent writers (QUEST-188)

### DIFF
--- a/internal/quest/cascade.go
+++ b/internal/quest/cascade.go
@@ -2,7 +2,6 @@ package quest
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"sort"
 )
@@ -24,7 +23,7 @@ import (
 // The returned slice is sorted by task_id so the cascade order is
 // deterministic — important for the emoji output in the CLI layer and
 // for test assertions.
-func findNewlyUnblocked(ctx context.Context, tx *sql.Tx, projectID string) ([]*Quest, error) {
+func findNewlyUnblocked(ctx context.Context, tx dbTx, projectID string) ([]*Quest, error) {
 	doneSet, err := loadDoneSet(ctx, tx, projectID)
 	if err != nil {
 		return nil, err
@@ -67,7 +66,7 @@ func findNewlyUnblocked(ctx context.Context, tx *sql.Tx, projectID string) ([]*Q
 
 // loadDoneSet returns the set of task_ids in projectID with status='done'.
 // Used by findNewlyUnblocked and Post's dep check.
-func loadDoneSet(ctx context.Context, tx *sql.Tx, projectID string) (map[string]bool, error) {
+func loadDoneSet(ctx context.Context, tx dbTx, projectID string) (map[string]bool, error) {
 	rows, err := tx.QueryContext(ctx,
 		`SELECT task_id FROM task_status WHERE project_id = ? AND status = 'done'`,
 		projectID,
@@ -93,7 +92,7 @@ func loadDoneSet(ctx context.Context, tx *sql.Tx, projectID string) (map[string]
 
 // loadBlockedIDs returns every task_id in projectID with status='blocked',
 // sorted for determinism.
-func loadBlockedIDs(ctx context.Context, tx *sql.Tx, projectID string) ([]string, error) {
+func loadBlockedIDs(ctx context.Context, tx dbTx, projectID string) ([]string, error) {
 	rows, err := tx.QueryContext(ctx,
 		`SELECT task_id FROM task_status
 		 WHERE project_id = ? AND status = 'blocked'
@@ -123,7 +122,7 @@ func loadBlockedIDs(ctx context.Context, tx *sql.Tx, projectID string) ([]string
 // emits an `unblocked` event citing completedID as the cause, and
 // returns the list in the same order. Runs inside the caller's tx so
 // partial progress can't leak on failure.
-func flipToNext(ctx context.Context, tx *sql.Tx, projectID, completedID string, unblocked []*Quest, now string) error {
+func flipToNext(ctx context.Context, tx dbTx, projectID, completedID string, unblocked []*Quest, now string) error {
 	for _, q := range unblocked {
 		if _, err := tx.ExecContext(ctx,
 			`UPDATE task_status

--- a/internal/quest/clear.go
+++ b/internal/quest/clear.go
@@ -46,15 +46,52 @@ func Fulfill(ctx context.Context, db *sql.DB, projectID, taskID, report string) 
 
 	now := time.Now().UTC().Format(time.RFC3339Nano)
 
-	tx, err := db.BeginTx(ctx, nil)
+	// Acquire a dedicated connection and open with BEGIN IMMEDIATE.
+	// DEFERRED transactions would take a read snapshot before the first
+	// write, causing concurrent Fulfill calls to read a stale done-set
+	// and miss each other's parent→done transitions during the cascade
+	// pass. BEGIN IMMEDIATE serializes writers at lock-acquisition time
+	// so every cascade reads a fully committed done-set.
+	conn, err := db.Conn(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("quest: clear: begin tx: %w", err)
+		return nil, fmt.Errorf("quest: clear: acquire conn: %w", err)
 	}
-	defer func() { _ = tx.Rollback() }()
+	defer func() { _ = conn.Close() }()
+
+	const maxBeginAttempts = 20
+	var beginErr error
+	for attempt := range maxBeginAttempts {
+		_, beginErr = conn.ExecContext(ctx, "BEGIN IMMEDIATE")
+		if beginErr == nil {
+			break
+		}
+		if !isBusyErr(beginErr.Error()) {
+			return nil, fmt.Errorf("quest: clear: begin immediate: %w", beginErr)
+		}
+		// Capped linear backoff: 10ms × attempt, max 200ms.
+		base := time.Duration(attempt+1) * 10 * time.Millisecond
+		if base > 200*time.Millisecond {
+			base = 200 * time.Millisecond
+		}
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("quest: clear: begin immediate: %w", ctx.Err())
+		case <-time.After(base):
+		}
+	}
+	if beginErr != nil {
+		return nil, fmt.Errorf("quest: clear: begin immediate (contended out after %d attempts): %w", maxBeginAttempts, beginErr)
+	}
+	committed := false
+	defer func() { //nolint:contextcheck // rollback must not be cancelled by a caller-cancelled ctx
+		if !committed {
+			_, _ = conn.ExecContext(context.Background(), "ROLLBACK")
+		}
+	}()
 
 	// Exists check — prevents silent no-op when the caller typos an id.
 	var existStatus, existOwner sql.NullString
-	err = tx.QueryRowContext(ctx,
+	err = conn.QueryRowContext(ctx,
 		`SELECT status, claimed_by FROM task_status
 		 WHERE project_id = ? AND task_id = ?`,
 		projectID, taskID,
@@ -70,7 +107,7 @@ func Fulfill(ctx context.Context, db *sql.DB, projectID, taskID, report string) 
 	// Mark done. We don't gate on status here — clearing an already-done
 	// quest is a no-op that still emits an event, and clearing an
 	// in_progress quest is the normal flow.
-	if _, err := tx.ExecContext(ctx,
+	if _, err := conn.ExecContext(ctx,
 		`UPDATE task_status
 		 SET status = 'done', updated_at = ?
 		 WHERE project_id = ? AND task_id = ?`,
@@ -80,7 +117,7 @@ func Fulfill(ctx context.Context, db *sql.DB, projectID, taskID, report string) 
 	}
 
 	// Done event with report payload (possibly empty).
-	if err := emitEvent(ctx, tx, projectID, taskID, EventDone, owner, report, now); err != nil {
+	if err := emitEvent(ctx, conn, projectID, taskID, EventDone, owner, report, now); err != nil {
 		return nil, err
 	}
 
@@ -90,7 +127,7 @@ func Fulfill(ctx context.Context, db *sql.DB, projectID, taskID, report string) 
 		if agent == "" {
 			agent = "agent"
 		}
-		if _, err := tx.ExecContext(ctx,
+		if _, err := conn.ExecContext(ctx,
 			`INSERT INTO task_notes (project_id, task_id, agent_id, note, created_at)
 			 VALUES (?, ?, ?, ?, ?)`,
 			projectID, taskID, agent, NotePrefixCompleted+r, now,
@@ -101,22 +138,23 @@ func Fulfill(ctx context.Context, db *sql.DB, projectID, taskID, report string) 
 
 	// Cascade-unblock pass. This reads the post-mark done-set, so taskID
 	// counts as done in the check.
-	unblocked, err := findNewlyUnblocked(ctx, tx, projectID)
+	unblocked, err := findNewlyUnblocked(ctx, conn, projectID)
 	if err != nil {
 		return nil, err
 	}
-	if err := flipToNext(ctx, tx, projectID, taskID, unblocked, now); err != nil {
+	if err := flipToNext(ctx, conn, projectID, taskID, unblocked, now); err != nil {
 		return nil, err
 	}
 
 	// Reload the cleared quest to return a complete view.
-	cleared, err := loadTx(ctx, tx, projectID, taskID)
+	cleared, err := loadTx(ctx, conn, projectID, taskID)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := tx.Commit(); err != nil {
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
 		return nil, fmt.Errorf("quest: clear: commit: %w", err)
 	}
+	committed = true
 	return &FulfillResult{Cleared: cleared, Unblocked: unblocked}, nil
 }

--- a/internal/quest/post.go
+++ b/internal/quest/post.go
@@ -227,7 +227,7 @@ func depsAllDone(ctx context.Context, tx *sql.Tx, projectID string, depIDs []str
 // insertSpecNote writes one row into task_notes with the given
 // pre-assembled note string. Note must already include its "[spec] " /
 // "[spec-replace] " / "[rework] of: " prefix.
-func insertSpecNote(ctx context.Context, tx *sql.Tx, projectID, taskID, agent, createdAt, note string) error {
+func insertSpecNote(ctx context.Context, tx dbTx, projectID, taskID, agent, createdAt, note string) error {
 	_, err := tx.ExecContext(ctx,
 		`INSERT INTO task_notes (project_id, task_id, agent_id, note, created_at)
 		 VALUES (?, ?, ?, ?, ?)`,
@@ -240,7 +240,7 @@ func insertSpecNote(ctx context.Context, tx *sql.Tx, projectID, taskID, agent, c
 }
 
 // emitEvent writes one row into task_events.
-func emitEvent(ctx context.Context, tx *sql.Tx, projectID, taskID, event, agent, data, createdAt string) error {
+func emitEvent(ctx context.Context, tx dbTx, projectID, taskID, event, agent, data, createdAt string) error {
 	_, err := tx.ExecContext(ctx,
 		`INSERT INTO task_events (project_id, task_id, event, agent_id, data, created_at)
 		 VALUES (?, ?, ?, ?, ?, ?)`,

--- a/internal/quest/spec.go
+++ b/internal/quest/spec.go
@@ -293,7 +293,7 @@ func Load(ctx context.Context, db *sql.DB, projectID, taskID string) (*Quest, er
 // loadTx is the transaction-bound form of Load used by Post/Accept/etc
 // after a write so the returned Quest reflects the in-tx state, not a
 // racing view of the db.
-func loadTx(ctx context.Context, tx *sql.Tx, projectID, taskID string) (*Quest, error) {
+func loadTx(ctx context.Context, tx queryer, projectID, taskID string) (*Quest, error) {
 	q, err := loadSpec(ctx, tx, projectID, taskID)
 	if err != nil {
 		return nil, err
@@ -309,4 +309,14 @@ func loadTx(ctx context.Context, tx *sql.Tx, projectID, taskID string) (*Quest, 
 type queryer interface {
 	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
 	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
+// dbTx is the read+write subset of *sql.Tx and *sql.Conn. Accepting this
+// interface instead of *sql.Tx lets Fulfill pin to a *sql.Conn and issue
+// BEGIN IMMEDIATE directly, without changing the cascade-helper signatures
+// visible to other callers (which continue to pass *sql.Tx and satisfy the
+// interface implicitly).
+type dbTx interface {
+	queryer
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
 }

--- a/internal/test/concurrency/concurrency_test.go
+++ b/internal/test/concurrency/concurrency_test.go
@@ -1,0 +1,153 @@
+package concurrency_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/mathomhaus/guild/internal/quest"
+	"github.com/mathomhaus/guild/internal/storage"
+)
+
+// newTestDB opens a file-backed SQLite DB under t.TempDir, applies migrations,
+// and registers a dummy project. A file DB (not :memory:) is required because
+// modernc.org/sqlite gives each goroutine an independent in-memory DB when
+// connection-string sharing isn't active — only a file path exercises real
+// concurrent write contention across the pool.
+func newTestDB(t *testing.T) (db *sql.DB, projectID string) {
+	t.Helper()
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "quest.db")
+	var err error
+	db, err = storage.Open(ctx, path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	if err = storage.Migrate(ctx, db, ""); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if _, err = db.ExecContext(ctx,
+		`INSERT INTO projects (id, path, tasks_file) VALUES (?, ?, ?)`,
+		"testproj", t.TempDir(), "TASKS.md",
+	); err != nil {
+		t.Fatalf("register project: %v", err)
+	}
+	return db, "testproj"
+}
+
+func mustPost(t *testing.T, db *sql.DB, pid string, params quest.PostParams) *quest.Quest {
+	t.Helper()
+	q, err := quest.Post(context.Background(), db, pid, params)
+	if err != nil {
+		t.Fatalf("Post %q: %v", params.Subject, err)
+	}
+	return q
+}
+
+func mustStatus(t *testing.T, db *sql.DB, pid, taskID string) quest.Status {
+	t.Helper()
+	var s sql.NullString
+	err := db.QueryRowContext(context.Background(),
+		`SELECT status FROM task_status WHERE project_id = ? AND task_id = ?`,
+		pid, taskID,
+	).Scan(&s)
+	if err != nil {
+		t.Fatalf("mustStatus %s: %v", taskID, err)
+	}
+	return quest.Status(s.String)
+}
+
+// Test_ConcurrentFulfillCascade_ChildrenFlipUnderContention fires N goroutines,
+// each fulfilling a distinct parent quest that blocks a dedicated child. After
+// the barrier, every child must be status=next — not blocked.
+//
+// Acceptance criteria from QUEST-188:
+//  1. All N children flip to next despite concurrent parent fulfillments.
+//  2. A shared sentinel depending on all N parents flips to next exactly once,
+//     after the last concurrent Fulfill commits.
+func Test_ConcurrentFulfillCascade_ChildrenFlipUnderContention(t *testing.T) {
+	for _, n := range []int{10, 100} {
+		n := n
+		t.Run(fmt.Sprintf("N=%d", n), func(t *testing.T) {
+			t.Parallel()
+			db, pid := newTestDB(t)
+			ctx := context.Background()
+
+			// Post N parent quests (all status=next; no deps).
+			parents := make([]*quest.Quest, n)
+			for i := range parents {
+				parents[i] = mustPost(t, db, pid, quest.PostParams{
+					Subject: fmt.Sprintf("parent-%d", i),
+				})
+			}
+
+			// Post N dedicated children, each blocking on its own parent.
+			children := make([]*quest.Quest, n)
+			for i := range children {
+				children[i] = mustPost(t, db, pid, quest.PostParams{
+					Subject:   fmt.Sprintf("child-%d", i),
+					DependsOn: []string{parents[i].ID},
+				})
+				if children[i].Status != quest.StatusBlocked {
+					t.Fatalf("child[%d] pre-condition: status=%s, want blocked", i, children[i].Status)
+				}
+			}
+
+			// Post a shared sentinel that depends on ALL N parents.
+			parentIDs := make([]string, n)
+			for i, p := range parents {
+				parentIDs[i] = p.ID
+			}
+			sentinel := mustPost(t, db, pid, quest.PostParams{
+				Subject:   "sentinel",
+				DependsOn: parentIDs,
+			})
+			if sentinel.Status != quest.StatusBlocked {
+				t.Fatalf("sentinel pre-condition: status=%s, want blocked", sentinel.Status)
+			}
+
+			// Concurrently fulfill all N parents.
+			var wg sync.WaitGroup
+			errs := make([]error, n)
+			wg.Add(n)
+			for i := range parents {
+				i := i
+				go func() {
+					defer wg.Done()
+					_, errs[i] = quest.Fulfill(ctx, db, pid, parents[i].ID, "")
+				}()
+			}
+			wg.Wait()
+
+			// Every Fulfill must have succeeded — no SQLITE_BUSY leaking to callers.
+			for i, err := range errs {
+				if err != nil {
+					t.Errorf("Fulfill parent[%d]: %v", i, err)
+				}
+			}
+
+			// Criterion 1: every dedicated child must be next, not blocked.
+			var stuck []string
+			for i, child := range children {
+				got := mustStatus(t, db, pid, child.ID)
+				if got != quest.StatusNext {
+					stuck = append(stuck, fmt.Sprintf("child[%d]=%s(%s)", i, child.ID, got))
+				}
+			}
+			if len(stuck) > 0 {
+				t.Errorf("N=%d: %d/%d children still blocked after concurrent fulfills: %v",
+					n, len(stuck), n, stuck)
+			}
+
+			// Criterion 2: the shared sentinel must be next (all N parents done).
+			if got := mustStatus(t, db, pid, sentinel.ID); got != quest.StatusNext {
+				t.Errorf("N=%d: sentinel status=%s, want next (all %d parents done)", n, got, n)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- **Root cause:** `Fulfill` opened its write transaction with `BEGIN DEFERRED`. Under concurrent writers, each transaction takes a read snapshot when the first `SELECT` executes. The cascade-unblock pass reads `loadDoneSet` from that stale snapshot, missing sibling parent→done transitions committed between snapshot and cascade. Children stay `blocked` even after all parents are `done`.
- **Fix:** Acquire a dedicated `*sql.Conn` and issue `BEGIN IMMEDIATE` before any reads. The write lock is held from transaction start, so the snapshot is always post-commit for all prior writers. Adds a capped-backoff retry loop (10–200 ms, up to 20 attempts) for the lock-acquisition step so high-concurrency callers serialize cleanly instead of surfacing `SQLITE_BUSY`.
- **Supporting changes:** Introduce `dbTx` interface (`queryer` + `ExecContext`) so cascade helpers and `emitEvent`/`insertSpecNote` accept either `*sql.Tx` or `*sql.Conn` without touching any existing caller. Change `loadTx` to accept `queryer` (already satisfied by both).

## Reproducer

`internal/test/concurrency/concurrency_test.go` — `Test_ConcurrentFulfillCascade_ChildrenFlipUnderContention`:

- Fires N goroutines, each fulfilling a distinct parent that blocks a dedicated child.
- Also posts a shared sentinel depending on all N parents.
- Asserts every child is `status=next` and the sentinel is `next` after the barrier.
- Confirmed RED before the fix (99/100 children blocked at N=100), GREEN after (all N pass at both N=10 and N=100, 5 consecutive `-race` runs).

## QUEST-189 status

`Fulfill` no longer surfaces `SQLITE_BUSY` to callers. `Post`, `Update`, and `Forfeit` still use `DEFERRED` and may surface `BUSY` under sustained high-write contention; that is tracked separately in QUEST-189.

## Test plan

- [ ] `go test -race -count=5 ./internal/test/concurrency/` — all pass
- [ ] `make check` — fmt + vet + lint + sqlcheck + test-race all green