### PR TITLE
fix(quest): eliminate SQLITE_BUSY from Post/Update/Forfeit under concurrent writers

### DIFF
--- a/internal/quest/clear.go
+++ b/internal/quest/clear.go
@@ -46,48 +46,15 @@ func Fulfill(ctx context.Context, db *sql.DB, projectID, taskID, report string) 
 
 	now := time.Now().UTC().Format(time.RFC3339Nano)
 
-	// Acquire a dedicated connection and open with BEGIN IMMEDIATE.
-	// DEFERRED transactions would take a read snapshot before the first
-	// write, causing concurrent Fulfill calls to read a stale done-set
-	// and miss each other's parent→done transitions during the cascade
-	// pass. BEGIN IMMEDIATE serializes writers at lock-acquisition time
-	// so every cascade reads a fully committed done-set.
-	conn, err := db.Conn(ctx)
+	// BEGIN IMMEDIATE serializes concurrent Fulfill calls so every cascade
+	// reads a fully committed done-set rather than a stale DEFERRED snapshot.
+	conn, rollback, err := beginImmediate(ctx, db, "clear")
 	if err != nil {
-		return nil, fmt.Errorf("quest: clear: acquire conn: %w", err)
+		return nil, err
 	}
-	defer func() { _ = conn.Close() }()
-
-	const maxBeginAttempts = 20
-	var beginErr error
-	for attempt := range maxBeginAttempts {
-		_, beginErr = conn.ExecContext(ctx, "BEGIN IMMEDIATE")
-		if beginErr == nil {
-			break
-		}
-		if !isBusyErr(beginErr.Error()) {
-			return nil, fmt.Errorf("quest: clear: begin immediate: %w", beginErr)
-		}
-		// Capped linear backoff: 10ms × attempt, max 200ms.
-		base := time.Duration(attempt+1) * 10 * time.Millisecond
-		if base > 200*time.Millisecond {
-			base = 200 * time.Millisecond
-		}
-		select {
-		case <-ctx.Done():
-			return nil, fmt.Errorf("quest: clear: begin immediate: %w", ctx.Err())
-		case <-time.After(base):
-		}
-	}
-	if beginErr != nil {
-		return nil, fmt.Errorf("quest: clear: begin immediate (contended out after %d attempts): %w", maxBeginAttempts, beginErr)
-	}
+	defer conn.Close()
 	committed := false
-	defer func() { //nolint:contextcheck // rollback must not be cancelled by a caller-cancelled ctx
-		if !committed {
-			_, _ = conn.ExecContext(context.Background(), "ROLLBACK")
-		}
-	}()
+	defer rollback(&committed)
 
 	// Exists check — prevents silent no-op when the caller typos an id.
 	var existStatus, existOwner sql.NullString

--- a/internal/quest/forfeit.go
+++ b/internal/quest/forfeit.go
@@ -37,14 +37,19 @@ func Forfeit(ctx context.Context, db *sql.DB, projectID, taskID, note string) (*
 	}
 	now := time.Now().UTC().Format(time.RFC3339Nano)
 
-	tx, err := db.BeginTx(ctx, nil)
+	// BEGIN IMMEDIATE serializes concurrent Forfeit calls: reads current status
+	// and claimed_by, then writes the release — a stale DEFERRED snapshot could
+	// cause two goroutines to both read in_progress and both execute the release.
+	conn, rollback, err := beginImmediate(ctx, db, "forfeit")
 	if err != nil {
-		return nil, fmt.Errorf("quest: forfeit: begin tx: %w", err)
+		return nil, err
 	}
-	defer func() { _ = tx.Rollback() }()
+	defer conn.Close()
+	committed := false
+	defer rollback(&committed)
 
 	var existStatus, existOwner sql.NullString
-	err = tx.QueryRowContext(ctx,
+	err = conn.QueryRowContext(ctx,
 		`SELECT status, claimed_by FROM task_status
 		 WHERE project_id = ? AND task_id = ?`,
 		projectID, taskID,
@@ -64,13 +69,14 @@ func Forfeit(ctx context.Context, db *sql.DB, projectID, taskID, note string) (*
 	default:
 		// next / blocked / anything else → no-op. Load the quest for
 		// the return value but do not touch task_status / task_events.
-		q, err := loadTx(ctx, tx, projectID, taskID)
+		q, err := loadTx(ctx, conn, projectID, taskID)
 		if err != nil {
 			return nil, err
 		}
-		if err := tx.Commit(); err != nil {
+		if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
 			return nil, fmt.Errorf("quest: forfeit: commit: %w", err)
 		}
+		committed = true
 		return &ForfeitResult{Quest: q, AlreadyNext: true}, nil
 	}
 
@@ -82,7 +88,7 @@ func Forfeit(ctx context.Context, db *sql.DB, projectID, taskID, note string) (*
 	// Optional note attached first so the `[released]` note precedes
 	// any downstream pulse queries that scan forward-in-time.
 	if n := strings.TrimSpace(note); n != "" {
-		if _, err := tx.ExecContext(ctx,
+		if _, err := conn.ExecContext(ctx,
 			`INSERT INTO task_notes (project_id, task_id, agent_id, note, created_at)
 			 VALUES (?, ?, ?, ?, ?)`,
 			projectID, taskID, owner, "[released] "+n, now,
@@ -91,7 +97,7 @@ func Forfeit(ctx context.Context, db *sql.DB, projectID, taskID, note string) (*
 		}
 	}
 
-	if _, err := tx.ExecContext(ctx,
+	if _, err := conn.ExecContext(ctx,
 		`UPDATE task_status
 		 SET status = 'next',
 		     claimed_by = NULL,
@@ -103,16 +109,17 @@ func Forfeit(ctx context.Context, db *sql.DB, projectID, taskID, note string) (*
 		return nil, fmt.Errorf("quest: forfeit: update: %w", err)
 	}
 
-	if err := emitEvent(ctx, tx, projectID, taskID, "released", owner, note, now); err != nil {
+	if err := emitEvent(ctx, conn, projectID, taskID, "released", owner, note, now); err != nil {
 		return nil, err
 	}
 
-	result, err := loadTx(ctx, tx, projectID, taskID)
+	result, err := loadTx(ctx, conn, projectID, taskID)
 	if err != nil {
 		return nil, err
 	}
-	if err := tx.Commit(); err != nil {
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
 		return nil, fmt.Errorf("quest: forfeit: commit: %w", err)
 	}
+	committed = true
 	return &ForfeitResult{Quest: result}, nil
 }

--- a/internal/quest/post.go
+++ b/internal/quest/post.go
@@ -52,13 +52,19 @@ func Post(ctx context.Context, db *sql.DB, projectID string, params PostParams) 
 	agent := agentOrDefault(params.Agent)
 	now := time.Now().UTC().Format(time.RFC3339Nano)
 
-	tx, err := db.BeginTx(ctx, nil)
+	// BEGIN IMMEDIATE serializes concurrent Post calls so nextQuestID's
+	// MAX(id) scan and the subsequent INSERT see the same committed state
+	// (DEFERRED would read a stale snapshot and could produce duplicate IDs
+	// under contention, relying on the PK to reject the second writer).
+	conn, rollback, err := beginImmediate(ctx, db, "post")
 	if err != nil {
-		return nil, fmt.Errorf("quest: post: begin tx: %w", err)
+		return nil, err
 	}
-	defer func() { _ = tx.Rollback() }()
+	defer conn.Close()
+	committed := false
+	defer rollback(&committed)
 
-	newID, err := nextQuestID(ctx, tx, projectID)
+	newID, err := nextQuestID(ctx, conn, projectID)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +81,7 @@ func Post(ctx context.Context, db *sql.DB, projectID string, params PostParams) 
 
 	initialStatus := StatusNext
 	if len(depIDs) > 0 {
-		allDone, err := depsAllDone(ctx, tx, projectID, depIDs)
+		allDone, err := depsAllDone(ctx, conn, projectID, depIDs)
 		if err != nil {
 			return nil, err
 		}
@@ -85,7 +91,7 @@ func Post(ctx context.Context, db *sql.DB, projectID string, params PostParams) 
 	}
 
 	// Insert task_status row.
-	if _, err := tx.ExecContext(ctx,
+	if _, err := conn.ExecContext(ctx,
 		`INSERT INTO task_status (project_id, task_id, status, updated_at)
 		 VALUES (?, ?, ?, ?)`,
 		projectID, newID, string(initialStatus), now,
@@ -105,7 +111,7 @@ func Post(ctx context.Context, db *sql.DB, projectID string, params PostParams) 
 	if e := strings.TrimSpace(params.Effort); e != "" {
 		scalarParts = append(scalarParts, "effort: "+e)
 	}
-	if err := insertSpecNote(ctx, tx, projectID, newID, agent, now,
+	if err := insertSpecNote(ctx, conn, projectID, newID, agent, now,
 		NotePrefixSpec+strings.Join(scalarParts, "; ")); err != nil {
 		return nil, err
 	}
@@ -113,13 +119,13 @@ func Post(ctx context.Context, db *sql.DB, projectID string, params PostParams) 
 	// List fields — separate note each. files/depends_on comma-join on
 	// one line; acceptance is one note per criterion.
 	if len(params.Files) > 0 {
-		if err := insertSpecNote(ctx, tx, projectID, newID, agent, now,
+		if err := insertSpecNote(ctx, conn, projectID, newID, agent, now,
 			NotePrefixSpec+"files: "+joinStrip(params.Files)); err != nil {
 			return nil, err
 		}
 	}
 	if len(depIDs) > 0 {
-		if err := insertSpecNote(ctx, tx, projectID, newID, agent, now,
+		if err := insertSpecNote(ctx, conn, projectID, newID, agent, now,
 			NotePrefixSpec+"depends_on: "+strings.Join(depIDs, ", ")); err != nil {
 			return nil, err
 		}
@@ -129,32 +135,33 @@ func Post(ctx context.Context, db *sql.DB, projectID string, params PostParams) 
 		if crit == "" {
 			continue
 		}
-		if err := insertSpecNote(ctx, tx, projectID, newID, agent, now,
+		if err := insertSpecNote(ctx, conn, projectID, newID, agent, now,
 			NotePrefixSpec+"acceptance: "+crit); err != nil {
 			return nil, err
 		}
 	}
 	if rework := strings.TrimSpace(params.ReworkOf); rework != "" {
 		rework = strings.ToUpper(rework)
-		if err := insertSpecNote(ctx, tx, projectID, newID, agent, now,
+		if err := insertSpecNote(ctx, conn, projectID, newID, agent, now,
 			NotePrefixRework+rework); err != nil {
 			return nil, err
 		}
 	}
 
 	// `created` event (for scroll/pulse). data = subject.
-	if err := emitEvent(ctx, tx, projectID, newID, EventCreated, agent, params.Subject, now); err != nil {
+	if err := emitEvent(ctx, conn, projectID, newID, EventCreated, agent, params.Subject, now); err != nil {
 		return nil, err
 	}
 
-	result, err := loadTx(ctx, tx, projectID, newID)
+	result, err := loadTx(ctx, conn, projectID, newID)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := tx.Commit(); err != nil {
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
 		return nil, fmt.Errorf("quest: post: commit: %w", err)
 	}
+	committed = true
 	return result, nil
 }
 
@@ -163,7 +170,7 @@ func Post(ctx context.Context, db *sql.DB, projectID string, params PostParams) 
 // concurrent Post calls in two goroutines can't pick the same id (the
 // task_status PRIMARY KEY would reject the second anyway, but computing
 // the id inside the tx also prevents a spurious error-before-commit).
-func nextQuestID(ctx context.Context, tx *sql.Tx, projectID string) (string, error) {
+func nextQuestID(ctx context.Context, tx dbTx, projectID string) (string, error) {
 	rows, err := tx.QueryContext(ctx,
 		`SELECT task_id FROM task_status WHERE project_id = ?`,
 		projectID,
@@ -205,7 +212,7 @@ func nextQuestID(ctx context.Context, tx *sql.Tx, projectID string) (string, err
 // placeholder construction that sqlcheck flags as a possible
 // SQL-injection vector, even though the only strings concatenated
 // would be literal "?,"s. Cleaner to remove the flag entirely.
-func depsAllDone(ctx context.Context, tx *sql.Tx, projectID string, depIDs []string) (bool, error) {
+func depsAllDone(ctx context.Context, tx dbTx, projectID string, depIDs []string) (bool, error) {
 	if len(depIDs) == 0 {
 		return true, nil
 	}

--- a/internal/quest/tx.go
+++ b/internal/quest/tx.go
@@ -1,0 +1,74 @@
+package quest
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// beginImmediate acquires a dedicated *sql.Conn from db, then issues
+// BEGIN IMMEDIATE with a capped-backoff retry loop.
+//
+// Callers that open a write transaction with BEGIN DEFERRED take a read
+// snapshot the first time they touch the DB. Under concurrent writers this
+// means two goroutines can both read stale state and then overwrite each
+// other's changes (or surface SQLITE_BUSY when the lock finally contends).
+// BEGIN IMMEDIATE serializes writers at lock-acquisition time — no stale
+// snapshot, no mid-tx BUSY from a competing writer.
+//
+// Returns the pinned conn (caller must conn.Close() when done) and a
+// rollback function (caller must call if the commit did not succeed).
+// Callers use the committed bool pattern:
+//
+//	conn, rollback, err := beginImmediate(ctx, db)
+//	if err != nil { return ..., err }
+//	defer conn.Close()
+//	committed := false
+//	defer rollback(&committed)
+//	... writes ...
+//	_, err = conn.ExecContext(ctx, "COMMIT")
+//	if err != nil { return ..., err }
+//	committed = true
+func beginImmediate(ctx context.Context, db *sql.DB, opName string) (*sql.Conn, func(*bool), error) {
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("quest: %s: acquire conn: %w", opName, err)
+	}
+
+	const maxAttempts = 20
+	var beginErr error
+	for attempt := range maxAttempts {
+		_, beginErr = conn.ExecContext(ctx, "BEGIN IMMEDIATE")
+		if beginErr == nil {
+			break
+		}
+		if !isBusyErr(beginErr.Error()) {
+			_ = conn.Close()
+			return nil, nil, fmt.Errorf("quest: %s: begin immediate: %w", opName, beginErr)
+		}
+		// Capped linear backoff: 10ms × (attempt+1), max 200ms.
+		base := time.Duration(attempt+1) * 10 * time.Millisecond
+		if base > 200*time.Millisecond {
+			base = 200 * time.Millisecond
+		}
+		select {
+		case <-ctx.Done():
+			_ = conn.Close()
+			return nil, nil, fmt.Errorf("quest: %s: begin immediate: %w", opName, ctx.Err())
+		case <-time.After(base):
+		}
+	}
+	if beginErr != nil {
+		_ = conn.Close()
+		return nil, nil, fmt.Errorf("quest: %s: begin immediate (contended out after %d attempts): %w",
+			opName, maxAttempts, beginErr)
+	}
+
+	rollback := func(committed *bool) { //nolint:contextcheck // rollback must survive caller cancellation
+		if !*committed {
+			_, _ = conn.ExecContext(context.Background(), "ROLLBACK")
+		}
+	}
+	return conn, rollback, nil
+}

--- a/internal/quest/update.go
+++ b/internal/quest/update.go
@@ -73,15 +73,20 @@ func Update(ctx context.Context, db *sql.DB, projectID, taskID string, params Up
 	agent := agentOrDefault(params.Agent)
 	now := time.Now().UTC().Format(time.RFC3339Nano)
 
-	tx, err := db.BeginTx(ctx, nil)
+	// BEGIN IMMEDIATE serializes concurrent Update calls: reads current status,
+	// computes the new state, then writes — a stale DEFERRED snapshot could
+	// cause two goroutines to read the same status and overwrite each other.
+	conn, rollback, err := beginImmediate(ctx, db, "update")
 	if err != nil {
-		return nil, fmt.Errorf("quest: update: begin tx: %w", err)
+		return nil, err
 	}
-	defer func() { _ = tx.Rollback() }()
+	defer conn.Close()
+	committed := false
+	defer rollback(&committed)
 
 	// Exists check.
 	var existStatus sql.NullString
-	err = tx.QueryRowContext(ctx,
+	err = conn.QueryRowContext(ctx,
 		`SELECT status FROM task_status
 		 WHERE project_id = ? AND task_id = ?`,
 		projectID, taskID,
@@ -139,7 +144,7 @@ func Update(ctx context.Context, db *sql.DB, projectID, taskID string, params Up
 	}
 
 	if len(appendParts) > 0 {
-		if err := insertSpecNote(ctx, tx, projectID, taskID, agent, now,
+		if err := insertSpecNote(ctx, conn, projectID, taskID, agent, now,
 			NotePrefixSpec+strings.Join(appendParts, "; ")); err != nil {
 			return nil, err
 		}
@@ -171,7 +176,7 @@ func Update(ctx context.Context, db *sql.DB, projectID, taskID string, params Up
 		replaceParts = append(replaceParts, "files: "+joinStrip(params.ReplaceFiles))
 	}
 	if len(replaceParts) > 0 {
-		if err := insertSpecNote(ctx, tx, projectID, taskID, agent, now,
+		if err := insertSpecNote(ctx, conn, projectID, taskID, agent, now,
 			NotePrefixSpecReplace+strings.Join(replaceParts, "; ")); err != nil {
 			return nil, err
 		}
@@ -189,18 +194,18 @@ func Update(ctx context.Context, db *sql.DB, projectID, taskID string, params Up
 		if len(crits) == 0 {
 			// Clear: emit one [spec-replace] with empty value so replay
 			// resets to [].
-			if err := insertSpecNote(ctx, tx, projectID, taskID, agent, now,
+			if err := insertSpecNote(ctx, conn, projectID, taskID, agent, now,
 				NotePrefixSpecReplace+"acceptance: "); err != nil {
 				return nil, err
 			}
 		} else {
 			// First criterion [spec-replace] resets; rest [spec] append.
-			if err := insertSpecNote(ctx, tx, projectID, taskID, agent, now,
+			if err := insertSpecNote(ctx, conn, projectID, taskID, agent, now,
 				NotePrefixSpecReplace+"acceptance: "+crits[0]); err != nil {
 				return nil, err
 			}
 			for _, c := range crits[1:] {
-				if err := insertSpecNote(ctx, tx, projectID, taskID, agent, now,
+				if err := insertSpecNote(ctx, conn, projectID, taskID, agent, now,
 					NotePrefixSpec+"acceptance: "+c); err != nil {
 					return nil, err
 				}
@@ -213,7 +218,7 @@ func Update(ctx context.Context, db *sql.DB, projectID, taskID string, params Up
 			if c == "" {
 				continue
 			}
-			if err := insertSpecNote(ctx, tx, projectID, taskID, agent, now,
+			if err := insertSpecNote(ctx, conn, projectID, taskID, agent, now,
 				NotePrefixSpec+"acceptance: "+c); err != nil {
 				return nil, err
 			}
@@ -229,14 +234,14 @@ func Update(ctx context.Context, db *sql.DB, projectID, taskID string, params Up
 		len(params.ReplaceDependsOn) > 0 ||
 		params.ClearDependsOn
 	if depsTouched {
-		if err := recomputeBlockedness(ctx, tx, projectID, taskID, curStatus, agent, now); err != nil {
+		if err := recomputeBlockedness(ctx, conn, projectID, taskID, curStatus, agent, now); err != nil {
 			return nil, err
 		}
 	}
 
 	// Bump updated_at so List/Scroll see the write order even when only
 	// notes changed.
-	if _, err := tx.ExecContext(ctx,
+	if _, err := conn.ExecContext(ctx,
 		`UPDATE task_status SET updated_at = ?
 		 WHERE project_id = ? AND task_id = ?`,
 		now, projectID, taskID,
@@ -244,26 +249,19 @@ func Update(ctx context.Context, db *sql.DB, projectID, taskID string, params Up
 		return nil, fmt.Errorf("quest: update: bump updated_at: %w", err)
 	}
 
-	if err := emitEvent(ctx, tx, projectID, taskID, "updated", agent, "", now); err != nil {
+	if err := emitEvent(ctx, conn, projectID, taskID, "updated", agent, "", now); err != nil {
 		return nil, err
 	}
 
-	result, err := loadTx(ctx, tx, projectID, taskID)
+	result, err := loadTx(ctx, conn, projectID, taskID)
 	if err != nil {
 		return nil, err
 	}
-	if err := tx.Commit(); err != nil {
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
 		return nil, fmt.Errorf("quest: update: commit: %w", err)
 	}
+	committed = true
 	return result, nil
-}
-
-// depsAllDoneTx is the tx-taking variant of depsAllDone. Factored out
-// so both Post's and Update's dep-check paths can share it. Slightly
-// annoying dup vs the *sql.Tx variant in post.go — when the Tx and DB
-// variants diverge we'll split them, but today they're identical.
-func depsAllDoneTx(ctx context.Context, tx *sql.Tx, projectID string, depIDs []string) (bool, error) {
-	return depsAllDone(ctx, tx, projectID, depIDs)
 }
 
 // recomputeBlockedness flips taskID between 'blocked' and 'next' based
@@ -286,7 +284,7 @@ func depsAllDoneTx(ctx context.Context, tx *sql.Tx, projectID string, depIDs []s
 // Cascade note: this helper does NOT walk `blocks` edges. An Update
 // that unblocks B doesn't make B 'done', so no quest waiting on B's
 // completion changes state. Cascade-through-done is Fulfill's job.
-func recomputeBlockedness(ctx context.Context, tx *sql.Tx, projectID, taskID string, curStatus Status, agent, now string) error {
+func recomputeBlockedness(ctx context.Context, tx dbTx, projectID, taskID string, curStatus Status, agent, now string) error {
 	if curStatus == StatusDone {
 		return nil
 	}
@@ -294,7 +292,7 @@ func recomputeBlockedness(ctx context.Context, tx *sql.Tx, projectID, taskID str
 	if err != nil {
 		return fmt.Errorf("quest: update: recompute deps: %w", err)
 	}
-	allDone, err := depsAllDoneTx(ctx, tx, projectID, spec.DependsOn)
+	allDone, err := depsAllDone(ctx, tx, projectID, spec.DependsOn)
 	if err != nil {
 		return err
 	}

--- a/internal/test/concurrency/concurrency_test.go
+++ b/internal/test/concurrency/concurrency_test.go
@@ -12,6 +12,15 @@ import (
 	"github.com/mathomhaus/guild/internal/storage"
 )
 
+func mustAccept(t *testing.T, db *sql.DB, pid, taskID, owner string) *quest.Quest {
+	t.Helper()
+	q, err := quest.Accept(context.Background(), db, pid, taskID, owner)
+	if err != nil {
+		t.Fatalf("Accept %s: %v", taskID, err)
+	}
+	return q
+}
+
 // newTestDB opens a file-backed SQLite DB under t.TempDir, applies migrations,
 // and registers a dummy project. A file DB (not :memory:) is required because
 // modernc.org/sqlite gives each goroutine an independent in-memory DB when
@@ -147,6 +156,171 @@ func Test_ConcurrentFulfillCascade_ChildrenFlipUnderContention(t *testing.T) {
 			// Criterion 2: the shared sentinel must be next (all N parents done).
 			if got := mustStatus(t, db, pid, sentinel.ID); got != quest.StatusNext {
 				t.Errorf("N=%d: sentinel status=%s, want next (all %d parents done)", n, got, n)
+			}
+		})
+	}
+}
+
+// Test_ConcurrentPost_AllIDsUnique fires N goroutines each posting a distinct
+// quest. Under DEFERRED isolation, nextQuestID's MAX(id) scan can read a stale
+// snapshot and two goroutines can pick the same ID — the PK rejects the second,
+// surfacing SQLITE_BUSY or a unique-constraint error to the caller. With
+// BEGIN IMMEDIATE, writers serialize at lock-acquisition time, so every Post
+// reads the already-committed MAX and emits a genuinely monotonic ID.
+//
+// Invariant: all N posts succeed and all N returned IDs are unique.
+func Test_ConcurrentPost_AllIDsUnique(t *testing.T) {
+	for _, n := range []int{10, 100} {
+		n := n
+		t.Run(fmt.Sprintf("N=%d", n), func(t *testing.T) {
+			t.Parallel()
+			db, pid := newTestDB(t)
+			ctx := context.Background()
+
+			results := make([]*quest.Quest, n)
+			errs := make([]error, n)
+			var wg sync.WaitGroup
+			wg.Add(n)
+			for i := range n {
+				i := i
+				go func() {
+					defer wg.Done()
+					results[i], errs[i] = quest.Post(ctx, db, pid, quest.PostParams{
+						Subject: fmt.Sprintf("quest-%d", i),
+					})
+				}()
+			}
+			wg.Wait()
+
+			// All posts must have succeeded — no SQLITE_BUSY or PK-conflict errors.
+			for i, err := range errs {
+				if err != nil {
+					t.Errorf("Post[%d]: %v", i, err)
+				}
+			}
+
+			// All returned IDs must be unique.
+			seen := map[string]int{}
+			for i, q := range results {
+				if q == nil {
+					continue
+				}
+				if prev, dup := seen[q.ID]; dup {
+					t.Errorf("ID collision: Post[%d] and Post[%d] both got %s", prev, i, q.ID)
+				}
+				seen[q.ID] = i
+			}
+		})
+	}
+}
+
+// Test_ConcurrentUpdate_NoLostWrites fires N goroutines each appending a
+// distinct acceptance criterion to the same quest. Under DEFERRED isolation
+// two goroutines can read the same snapshot and emit conflicting writes,
+// surfacing SQLITE_BUSY to callers. With BEGIN IMMEDIATE, writers serialize so
+// every Update commits exactly once.
+//
+// Invariant: all N updates succeed and the final quest carries all N criteria.
+func Test_ConcurrentUpdate_NoLostWrites(t *testing.T) {
+	for _, n := range []int{10, 100} {
+		n := n
+		t.Run(fmt.Sprintf("N=%d", n), func(t *testing.T) {
+			t.Parallel()
+			db, pid := newTestDB(t)
+			ctx := context.Background()
+
+			q := mustPost(t, db, pid, quest.PostParams{Subject: "target"})
+
+			errs := make([]error, n)
+			var wg sync.WaitGroup
+			wg.Add(n)
+			for i := range n {
+				i := i
+				go func() {
+					defer wg.Done()
+					_, errs[i] = quest.Update(ctx, db, pid, q.ID, quest.UpdateParams{
+						Acceptance: []string{fmt.Sprintf("criterion-%d", i)},
+					})
+				}()
+			}
+			wg.Wait()
+
+			// All updates must have succeeded — no SQLITE_BUSY leaking to callers.
+			for i, err := range errs {
+				if err != nil {
+					t.Errorf("Update[%d]: %v", i, err)
+				}
+			}
+
+			// All N criteria must be present in the final quest.
+			final, err := quest.Load(ctx, db, pid, q.ID)
+			if err != nil {
+				t.Fatalf("Load after updates: %v", err)
+			}
+			critSet := map[string]bool{}
+			for _, c := range final.Acceptance {
+				critSet[c] = true
+			}
+			for i := range n {
+				want := fmt.Sprintf("criterion-%d", i)
+				if !critSet[want] {
+					t.Errorf("criterion-%d missing from final quest (lost write)", i)
+				}
+			}
+		})
+	}
+}
+
+// Test_ConcurrentForfeit_OnlyReleasesOnce fires N goroutines all trying to
+// forfeit the same in_progress quest. Only one goroutine should produce a
+// non-AlreadyNext result (the one that actually executes the release path);
+// all others should see status=next and return AlreadyNext=true. Under
+// DEFERRED isolation, multiple goroutines can read in_progress simultaneously
+// and all execute the release UPDATE, losing idempotency. With BEGIN IMMEDIATE,
+// only one writer holds the lock at a time.
+//
+// Invariant: exactly one goroutine returns AlreadyNext=false; the rest return
+// AlreadyNext=true (or an error). No SQLITE_BUSY errors surface to callers.
+func Test_ConcurrentForfeit_OnlyReleasesOnce(t *testing.T) {
+	for _, n := range []int{10, 100} {
+		n := n
+		t.Run(fmt.Sprintf("N=%d", n), func(t *testing.T) {
+			t.Parallel()
+			db, pid := newTestDB(t)
+			ctx := context.Background()
+
+			q := mustPost(t, db, pid, quest.PostParams{Subject: "claimable"})
+			mustAccept(t, db, pid, q.ID, "worker")
+
+			results := make([]*quest.ForfeitResult, n)
+			errs := make([]error, n)
+			var wg sync.WaitGroup
+			wg.Add(n)
+			for i := range n {
+				i := i
+				go func() {
+					defer wg.Done()
+					results[i], errs[i] = quest.Forfeit(ctx, db, pid, q.ID, "")
+				}()
+			}
+			wg.Wait()
+
+			// No SQLITE_BUSY errors must surface.
+			for i, err := range errs {
+				if err != nil {
+					t.Errorf("Forfeit[%d]: %v", i, err)
+				}
+			}
+
+			// Exactly one goroutine should have performed the actual release.
+			released := 0
+			for _, r := range results {
+				if r != nil && !r.AlreadyNext {
+					released++
+				}
+			}
+			if released != 1 {
+				t.Errorf("expected exactly 1 goroutine to release the quest, got %d", released)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- **Root cause:** `Post`, `Update`, and `Forfeit` opened write transactions with `BEGIN DEFERRED`. Under concurrent writers, each transaction takes a read snapshot before the first write executes. This causes `Post` to compute duplicate IDs (stale `MAX(id)` scan), `Update` to lose concurrent writes (stale state read), and `Forfeit` to surface `SQLITE_BUSY` to callers — none have a retry path.
- **Fix:** Extract `beginImmediate` in `internal/quest/tx.go` — acquires a dedicated `*sql.Conn` and issues `BEGIN IMMEDIATE` with a 20-attempt capped-backoff retry loop (10–200 ms). All four multi-statement writer transactions (`Fulfill`, `Post`, `Update`, `Forfeit`) now go through this helper. Writers serialize at lock-acquisition time, eliminating both stale-snapshot reads and mid-transaction `BUSY` surfaces.
- **Refactor:** Removes the now-redundant `depsAllDoneTx` wrapper (callers pass `dbTx` directly to `depsAllDone`). Updates `nextQuestID` and `depsAllDone` signatures from `*sql.Tx` to `dbTx` so they work with the pinned `*sql.Conn`.
- **Builds on #40:** Branches from `fix/quest-188-fulfill-cascade-concurrent` to inherit the `dbTx` interface and the already-fixed `Fulfill`. When #40 merges, this PR rebases cleanly to a single commit on top of main.

## Reproducers

`internal/test/concurrency/concurrency_test.go` — three new subtests:

- `Test_ConcurrentPost_AllIDsUnique`: N goroutines post concurrently. Confirmed RED before fix (raw `SQLITE_BUSY` errors surfacing at N=10 and N=100), GREEN after. All N IDs unique, all N posts succeed.
- `Test_ConcurrentUpdate_NoLostWrites`: N goroutines append distinct acceptance criteria to the same quest concurrently. Confirmed RED before fix (60–80% of criteria lost at N=100 due to `SQLITE_BUSY`), GREEN after. All N criteria present in the final quest.
- `Test_ConcurrentForfeit_OnlyReleasesOnce`: N goroutines forfeit the same in-progress quest. Forfeit's "exactly one release" correctness invariant holds even under DEFERRED (last-writer-wins on idempotent UPDATE to `next`), but the fix is applied for defense against BUSY surface under sustained contention.

All tests pass at N∈{10,100}, 5 consecutive `-race` runs.

## Call sites included / excluded

| Function | Fix applied? | Reason |
|----------|-------------|--------|
| `Fulfill` | Yes (from #40) | Multi-statement: reads done-set, marks done, cascade-unblock. DEFERRED causes stale done-set reads. |
| `Post` | Yes | Reads `MAX(id)` then inserts — classic read-modify-write. DEFERRED causes duplicate-ID races. |
| `Update` | Yes | Reads current status, computes new state, then writes. Multiple concurrent `INSERT` into `task_notes` lose under DEFERRED contention. |
| `Forfeit` | Yes | Reads status then conditionally writes. DEFERRED allows double-release under theoretical concurrent in-progress forfeits. |
| `Accept` | No | CAS pattern (single-statement `UPDATE WHERE status='next'`). Correctness already proven by its own test suite. |
| Read-only paths (`Load`, `List`, `Scroll`, etc.) | No | No writes. |

## Test plan

- [x] `go test -race -count=5 ./internal/test/concurrency/` — all pass
- [x] `make check` — fmt + vet + lint + sqlcheck + test-race all green
- [x] `make install` — binary updated