### PR TITLE
fix(lore,quest): extract shared BeginImmediate helper and migrate remaining write paths (QUEST-199/200/201)

### DIFF
--- a/internal/lore/appraise.go
+++ b/internal/lore/appraise.go
@@ -358,13 +358,15 @@ func bumpAccessCounters(ctx context.Context, db *sql.DB, now time.Time, results 
 	if len(results) == 0 {
 		return nil
 	}
-	tx, err := db.BeginTx(ctx, nil)
+	conn, rollback, err := beginImmediate(ctx, db, "appraise access")
 	if err != nil {
-		return fmt.Errorf("lore: bump access: begin: %w", err)
+		return fmt.Errorf("lore: bump access: %w", err)
 	}
-	defer func() { _ = tx.Rollback() }()
+	defer conn.Close()
+	committed := false
+	defer rollback(&committed)
 
-	stmt, err := tx.PrepareContext(ctx,
+	stmt, err := conn.PrepareContext(ctx,
 		`UPDATE entries SET access_count = access_count + 1, last_accessed_at = ? WHERE id = ?`)
 	if err != nil {
 		return fmt.Errorf("lore: bump access: prepare: %w", err)
@@ -377,7 +379,11 @@ func bumpAccessCounters(ctx context.Context, db *sql.DB, now time.Time, results 
 			return fmt.Errorf("lore: bump access: exec: %w", err)
 		}
 	}
-	return tx.Commit()
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+		return fmt.Errorf("lore: bump access: commit: %w", err)
+	}
+	committed = true
+	return nil
 }
 
 // entryColumns is the fixed SELECT list for the `entries` table. Declared

--- a/internal/lore/concurrency_test.go
+++ b/internal/lore/concurrency_test.go
@@ -1,0 +1,139 @@
+package lore
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestReforge_ConcurrentPairsAllSucceed exercises concurrent reforge writes on
+// distinct entry pairs. Every pair should commit without SQLITE_BUSY leaks, and
+// each old entry should end superseded with exactly one supersedes edge.
+func TestReforge_ConcurrentPairsAllSucceed(t *testing.T) {
+	const n = 20
+
+	ctx := context.Background()
+	db := openTestDB(t, "alpha")
+
+	type pair struct {
+		oldID int64
+		newID int64
+	}
+	pairs := make([]pair, n)
+	for i := range pairs {
+		oldE, err := Inscribe(ctx, db, &InscribeParams{
+			ProjectID: "alpha",
+			Kind:      KindDecision,
+			Title:     fmt.Sprintf("old reforge target %d", i),
+			Summary:   "summary",
+			Topic:     "concurrency",
+		})
+		if err != nil {
+			t.Fatalf("inscribe old %d: %v", i, err)
+		}
+		newE, err := Inscribe(ctx, db, &InscribeParams{
+			ProjectID: "alpha",
+			Kind:      KindDecision,
+			Title:     fmt.Sprintf("new reforge target %d", i),
+			Summary:   "summary",
+			Topic:     "concurrency",
+		})
+		if err != nil {
+			t.Fatalf("inscribe new %d: %v", i, err)
+		}
+		pairs[i] = pair{oldID: oldE.Entry.ID, newID: newE.Entry.ID}
+	}
+
+	errs := make([]error, n)
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := range pairs {
+		i := i
+		go func() {
+			defer wg.Done()
+			errs[i] = Reforge(ctx, db, pairs[i].oldID, pairs[i].newID, time.Time{})
+		}()
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("Reforge[%d]: %v", i, err)
+		}
+	}
+
+	for _, p := range pairs {
+		var status string
+		if err := db.QueryRowContext(ctx,
+			`SELECT status FROM entries WHERE id = ?`,
+			p.oldID,
+		).Scan(&status); err != nil {
+			t.Fatalf("load old entry %d: %v", p.oldID, err)
+		}
+		if status != string(StatusSuperseded) {
+			t.Errorf("old entry %d status=%q, want superseded", p.oldID, status)
+		}
+		var links int
+		if err := db.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM entry_links
+			 WHERE from_id = ? AND to_id = ? AND relation = 'supersedes'`,
+			p.newID, p.oldID,
+		).Scan(&links); err != nil {
+			t.Fatalf("count links %d->%d: %v", p.newID, p.oldID, err)
+		}
+		if links != 1 {
+			t.Errorf("supersedes links for %d->%d = %d, want 1", p.newID, p.oldID, links)
+		}
+	}
+}
+
+// TestAppraise_ConcurrentAccessCounterBumps runs N concurrent appraise calls
+// against the same entry and asserts the telemetry write path records every
+// access. Appraise intentionally swallows bump errors, so the count is the
+// only proof the write path survived contention.
+func TestAppraise_ConcurrentAccessCounterBumps(t *testing.T) {
+	const n = 20
+
+	ctx := context.Background()
+	db := openTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	ids := seedCorpus(t, ctx, db, []fixtureEntry{
+		{"p", "research", "counter contention entry", "summary", "t"},
+	})
+
+	errs := make([]error, n)
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := range n {
+		i := i
+		go func() {
+			defer wg.Done()
+			_, errs[i] = Appraise(ctx, db, AppraiseParams{
+				Query:       "counter contention",
+				AllProjects: true,
+				Now:         time.Now().UTC(),
+			})
+		}()
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("Appraise[%d]: %v", i, err)
+		}
+	}
+
+	var count int
+	if err := db.QueryRowContext(ctx,
+		`SELECT access_count FROM entries WHERE id = ?`,
+		ids[0],
+	).Scan(&count); err != nil {
+		t.Fatalf("scan access_count: %v", err)
+	}
+	if count != n {
+		t.Fatalf("access_count=%d, want %d", count, n)
+	}
+}

--- a/internal/lore/inscribe.go
+++ b/internal/lore/inscribe.go
@@ -183,6 +183,11 @@ func Inscribe(ctx context.Context, db *sql.DB, p *InscribeParams) (*InscribeResu
 		validDays = kindValidDays(p.Kind)
 	}
 
+	filePath, err := canonicalizeProjectFilePath(ctx, db, p.ProjectID, p.FilePath)
+	if err != nil {
+		return nil, err
+	}
+
 	tags := strings.Join(p.Tags, ",")
 
 	// Prepared INSERT — fixed SQL, bound values.
@@ -197,7 +202,7 @@ func Inscribe(ctx context.Context, db *sql.DB, p *InscribeParams) (*InscribeResu
 		p.Title,
 		p.Summary,
 		nullIfEmpty(tags),
-		nullIfEmpty(p.FilePath),
+		nullIfEmpty(filePath),
 		nullIfEmpty(p.Source),
 		string(status),
 		nullIfNilInt(validDays),
@@ -222,7 +227,7 @@ func Inscribe(ctx context.Context, db *sql.DB, p *InscribeParams) (*InscribeResu
 		Title:       p.Title,
 		Summary:     p.Summary,
 		Tags:        append([]string(nil), p.Tags...),
-		FilePath:    p.FilePath,
+		FilePath:    filePath,
 		Source:      p.Source,
 		Status:      status,
 		ValidDays:   validDays,

--- a/internal/lore/inscribe_test.go
+++ b/internal/lore/inscribe_test.go
@@ -127,6 +127,28 @@ func TestInscribe_RequiresFields(t *testing.T) {
 	}
 }
 
+func TestInscribe_FilePathRelativeCanonicalizedToProjectRoot(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t, "alpha")
+
+	res, err := Inscribe(ctx, db, &InscribeParams{
+		ProjectID: "alpha",
+		Kind:      KindDecision,
+		Title:     "relative file path canonicalization",
+		Summary:   "summary body",
+		Topic:     "paths",
+		FilePath:  "docs/decision.md",
+	})
+	if err != nil {
+		t.Fatalf("Inscribe: %v", err)
+	}
+
+	want := filepath.Clean("/fake/alpha/docs/decision.md")
+	if res.Entry.FilePath != want {
+		t.Fatalf("entry file_path=%q, want %q", res.Entry.FilePath, want)
+	}
+}
+
 // TestInscribe_CrossProjectDedup_Default verifies the default behavior
 // (StrictProject=false): an entry with the same title in project BETA
 // surfaces the original ENTRY-1 (created in project ALPHA) as a dedup

--- a/internal/lore/link.go
+++ b/internal/lore/link.go
@@ -64,10 +64,14 @@ func LinkEntries(ctx context.Context, db *sql.DB, fromID, toID int64, rel Relati
 	return nil
 }
 
+type entryLookup interface {
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
 // requireEntryExists returns nil if id exists in entries (regardless of
 // project), or a wrapped ErrEntryNotFound otherwise. Used by Link and
 // Reforge to reject IDs before doing the mutation.
-func requireEntryExists(ctx context.Context, db *sql.DB, id int64) error {
+func requireEntryExists(ctx context.Context, db entryLookup, id int64) error {
 	var exists int
 	err := db.QueryRowContext(ctx,
 		`SELECT 1 FROM entries WHERE id = ?`, id,

--- a/internal/lore/path.go
+++ b/internal/lore/path.go
@@ -1,0 +1,41 @@
+package lore
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// canonicalizeProjectFilePath normalizes a stored lore file_path.
+//
+// Empty stays empty. Absolute paths are cleaned in-place. Relative paths are
+// resolved against the registered project root so later git-aware reads do not
+// depend on the guild process's ambient cwd.
+func canonicalizeProjectFilePath(ctx context.Context, db *sql.DB, projectID, raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", nil
+	}
+	if filepath.IsAbs(raw) {
+		return filepath.Clean(raw), nil
+	}
+
+	var projectRoot string
+	err := db.QueryRowContext(ctx,
+		`SELECT path FROM projects WHERE id = ?`,
+		projectID,
+	).Scan(&projectRoot)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return "", fmt.Errorf("lore: canonicalize file_path: project %q not found", projectID)
+		}
+		return "", fmt.Errorf("lore: canonicalize file_path: lookup project %q: %w", projectID, err)
+	}
+	projectRoot = strings.TrimSpace(projectRoot)
+	if projectRoot == "" {
+		return "", fmt.Errorf("lore: canonicalize file_path: project %q has empty path", projectID)
+	}
+	return filepath.Clean(filepath.Join(projectRoot, raw)), nil
+}

--- a/internal/lore/reforge.go
+++ b/internal/lore/reforge.go
@@ -45,26 +45,26 @@ func Reforge(ctx context.Context, db *sql.DB, oldID, newID int64, now time.Time)
 		now = time.Now().UTC()
 	}
 
-	// Verify both entries exist before opening a transaction. Keeps the
-	// error case cheap; also produces clearer errors ("LORE-99 not
-	// found") than a post-rollback one.
-	if err := requireEntryExists(ctx, db, oldID); err != nil {
-		return err
-	}
-	if err := requireEntryExists(ctx, db, newID); err != nil {
-		return err
-	}
-
-	tx, err := db.BeginTx(ctx, nil)
+	conn, rollback, err := beginImmediate(ctx, db, "reforge")
 	if err != nil {
-		return fmt.Errorf("lore: reforge: begin tx: %w", err)
+		return err
 	}
-	// Rollback is a no-op after Commit; safe to always-defer.
-	defer func() { _ = tx.Rollback() }()
+	defer conn.Close()
+	committed := false
+	defer rollback(&committed)
+
+	// Verify both entries exist inside the pinned transaction so the
+	// validation and the mutation share one serialized view.
+	if err := requireEntryExists(ctx, conn, oldID); err != nil {
+		return err
+	}
+	if err := requireEntryExists(ctx, conn, newID); err != nil {
+		return err
+	}
 
 	// Step 1: mark oldID superseded. Touch updated_at so the CLI study
 	// view shows when the state actually changed (not just created_at).
-	if _, err := tx.ExecContext(ctx,
+	if _, err := conn.ExecContext(ctx,
 		`UPDATE entries
 		   SET status = 'superseded', updated_at = ?
 		 WHERE id = ?`,
@@ -84,7 +84,7 @@ func Reforge(ctx context.Context, db *sql.DB, oldID, newID int64, now time.Time)
 	// Step 2: write the provenance edge newID → oldID, relation=supersedes.
 	// INSERT OR IGNORE so repeated reforges (rare) are idempotent at the
 	// edge level — duplicate supersedes edges carry no new information.
-	if _, err := tx.ExecContext(ctx,
+	if _, err := conn.ExecContext(ctx,
 		`INSERT OR IGNORE INTO entry_links (from_id, to_id, relation)
 		 VALUES (?, ?, 'supersedes')`,
 		newID, oldID,
@@ -92,8 +92,9 @@ func Reforge(ctx context.Context, db *sql.DB, oldID, newID int64, now time.Time)
 		return fmt.Errorf("lore: reforge: insert link: %w", err)
 	}
 
-	if err := tx.Commit(); err != nil {
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
 		return fmt.Errorf("lore: reforge: commit: %w", err)
 	}
+	committed = true
 	return nil
 }

--- a/internal/lore/restore.go
+++ b/internal/lore/restore.go
@@ -127,7 +127,10 @@ func restoreV1(ctx context.Context, db *sql.DB, projectID string, data []byte) (
 		}
 
 		tags := strings.TrimSpace(e.Tags)
-		filePath := strings.TrimSpace(e.FilePath)
+		filePath, err := canonicalizeProjectFilePath(ctx, db, projectID, e.FilePath)
+		if err != nil {
+			return nil, fmt.Errorf("lore: restore v1: canonicalize file_path for entry %d: %w", oldID, err)
+		}
 		source := strings.TrimSpace(e.Source)
 		promptedBy := strings.TrimSpace(e.PromptedBy)
 

--- a/internal/lore/restore_test.go
+++ b/internal/lore/restore_test.go
@@ -317,3 +317,40 @@ func TestArchiveRestoreRoundTrip(t *testing.T) {
 		t.Errorf("restored title = %q; want 'Go error handling'", title)
 	}
 }
+
+func TestRestore_CanonicalizesRelativeFilePathToProjectRoot(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t, "restore-paths")
+
+	snapshotPath := filepath.Join(t.TempDir(), "snapshot.json")
+	writeTestSnapshot(t, snapshotPath, 1, []snapshotLoreEntry{
+		{
+			ID:       1,
+			Topic:    "paths",
+			Kind:     string(KindDecision),
+			Title:    "relative path entry",
+			Summary:  "summary",
+			FilePath: "docs/decision.md",
+		},
+	}, nil)
+
+	result, err := Restore(ctx, db, "restore-paths", snapshotPath)
+	if err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	if result.Imported != 1 {
+		t.Fatalf("Imported=%d, want 1", result.Imported)
+	}
+
+	var got string
+	if err := db.QueryRowContext(ctx,
+		`SELECT COALESCE(file_path, '') FROM entries WHERE project_id = ?`,
+		"restore-paths",
+	).Scan(&got); err != nil {
+		t.Fatalf("read file_path: %v", err)
+	}
+	want := filepath.Clean("/fake/restore-paths/docs/decision.md")
+	if got != want {
+		t.Fatalf("file_path=%q, want %q", got, want)
+	}
+}

--- a/internal/lore/tx.go
+++ b/internal/lore/tx.go
@@ -1,0 +1,14 @@
+package lore
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/mathomhaus/guild/internal/storage"
+)
+
+// beginImmediate is the lore-scoped wrapper over storage.BeginImmediate so
+// lore callers get consistent "lore: <op>" error prefixes.
+func beginImmediate(ctx context.Context, db *sql.DB, opName string) (*sql.Conn, func(*bool), error) {
+	return storage.BeginImmediate(ctx, db, "lore: "+opName)
+}

--- a/internal/quest/campfire.go
+++ b/internal/quest/campfire.go
@@ -55,9 +55,22 @@ func Campfire(ctx context.Context, db *sql.DB, projectID, questID string, p Camp
 
 	agent := journalAgent(p.Agent)
 
-	// Verify quest exists.
+	snapshot := buildCampfireSnapshot(p)
+	noteText := NotePrefixCheckpoint + snapshot
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+
+	conn, rollback, err := beginImmediate(ctx, db, "campfire")
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	committed := false
+	defer rollback(&committed)
+
+	// Verify quest exists inside the pinned transaction so the check and
+	// the note/event append share one serialized view.
 	var n int
-	err := db.QueryRowContext(ctx,
+	err = conn.QueryRowContext(ctx,
 		`SELECT COUNT(*) FROM task_status WHERE project_id = ? AND task_id = ?`,
 		projectID, questID,
 	).Scan(&n)
@@ -68,17 +81,7 @@ func Campfire(ctx context.Context, db *sql.DB, projectID, questID string, p Camp
 		return fmt.Errorf("%w: %s", ErrNotFound, questID)
 	}
 
-	snapshot := buildCampfireSnapshot(p)
-	noteText := NotePrefixCheckpoint + snapshot
-	now := time.Now().UTC().Format(time.RFC3339Nano)
-
-	tx, err := db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("quest: campfire: begin tx: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
-
-	if _, err := tx.ExecContext(ctx,
+	if _, err := conn.ExecContext(ctx,
 		`INSERT INTO task_notes (project_id, task_id, agent_id, note, created_at)
 		 VALUES (?, ?, ?, ?, ?)`,
 		projectID, questID, agent, noteText, now,
@@ -86,13 +89,14 @@ func Campfire(ctx context.Context, db *sql.DB, projectID, questID string, p Camp
 		return fmt.Errorf("quest: campfire: insert note: %w", err)
 	}
 
-	if err := emitEvent(ctx, tx, projectID, questID, "checkpoint", agent, snapshot, now); err != nil {
+	if err := emitEvent(ctx, conn, projectID, questID, "checkpoint", agent, snapshot, now); err != nil {
 		return err
 	}
 
-	if err := tx.Commit(); err != nil {
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
 		return fmt.Errorf("quest: campfire: commit: %w", err)
 	}
+	committed = true
 	return nil
 }
 

--- a/internal/quest/epic.go
+++ b/internal/quest/epic.go
@@ -41,11 +41,13 @@ func SetEpic(ctx context.Context, db *sql.DB, projectID, epic string, taskIDs []
 	now := time.Now().UTC().Format(time.RFC3339Nano)
 	agent := agentOrDefault("")
 
-	tx, err := db.BeginTx(ctx, nil)
+	conn, rollback, err := beginImmediate(ctx, db, "epic")
 	if err != nil {
-		return nil, fmt.Errorf("quest: epic: begin tx: %w", err)
+		return nil, err
 	}
-	defer func() { _ = tx.Rollback() }()
+	defer conn.Close()
+	committed := false
+	defer rollback(&committed)
 
 	for _, raw := range taskIDs {
 		tid := strings.ToUpper(strings.TrimSpace(raw))
@@ -54,7 +56,7 @@ func SetEpic(ctx context.Context, db *sql.DB, projectID, epic string, taskIDs []
 		}
 		// Existence probe.
 		var exists int
-		err := tx.QueryRowContext(ctx,
+		err := conn.QueryRowContext(ctx,
 			`SELECT 1 FROM task_status
 			 WHERE project_id = ? AND task_id = ?`,
 			projectID, tid,
@@ -66,15 +68,16 @@ func SetEpic(ctx context.Context, db *sql.DB, projectID, epic string, taskIDs []
 			}
 			return nil, fmt.Errorf("quest: epic: probe %s: %w", tid, err)
 		}
-		if err := insertSpecNote(ctx, tx, projectID, tid, agent, now,
+		if err := insertSpecNote(ctx, conn, projectID, tid, agent, now,
 			NotePrefixSpec+"epic: "+epic); err != nil {
 			return nil, err
 		}
 		result.Applied = append(result.Applied, tid)
 	}
 
-	if err := tx.Commit(); err != nil {
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
 		return nil, fmt.Errorf("quest: epic: commit: %w", err)
 	}
+	committed = true
 	return result, nil
 }

--- a/internal/quest/journal.go
+++ b/internal/quest/journal.go
@@ -36,9 +36,20 @@ func Journal(ctx context.Context, db *sql.DB, projectID, questID, agent, text st
 	}
 	agent = journalAgent(agent)
 
-	// Verify quest exists.
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+
+	conn, rollback, err := beginImmediate(ctx, db, "journal")
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	committed := false
+	defer rollback(&committed)
+
+	// Verify quest exists inside the pinned transaction so the check and
+	// the note/event append share one serialized view.
 	var n int
-	err := db.QueryRowContext(ctx,
+	err = conn.QueryRowContext(ctx,
 		`SELECT COUNT(*) FROM task_status WHERE project_id = ? AND task_id = ?`,
 		projectID, questID,
 	).Scan(&n)
@@ -49,15 +60,7 @@ func Journal(ctx context.Context, db *sql.DB, projectID, questID, agent, text st
 		return fmt.Errorf("%w: %s", ErrNotFound, questID)
 	}
 
-	now := time.Now().UTC().Format(time.RFC3339Nano)
-
-	tx, err := db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("quest: journal: begin tx: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
-
-	if _, err := tx.ExecContext(ctx,
+	if _, err := conn.ExecContext(ctx,
 		`INSERT INTO task_notes (project_id, task_id, agent_id, note, created_at)
 		 VALUES (?, ?, ?, ?, ?)`,
 		projectID, questID, agent, text, now,
@@ -65,13 +68,14 @@ func Journal(ctx context.Context, db *sql.DB, projectID, questID, agent, text st
 		return fmt.Errorf("quest: journal: insert note: %w", err)
 	}
 
-	if err := emitEvent(ctx, tx, projectID, questID, EventNoted, agent, text, now); err != nil {
+	if err := emitEvent(ctx, conn, projectID, questID, EventNoted, agent, text, now); err != nil {
 		return err
 	}
 
-	if err := tx.Commit(); err != nil {
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
 		return fmt.Errorf("quest: journal: commit: %w", err)
 	}
+	committed = true
 	return nil
 }
 

--- a/internal/quest/restore.go
+++ b/internal/quest/restore.go
@@ -68,16 +68,18 @@ func Restore(ctx context.Context, db *sql.DB, projectID, snapshotPath string) (*
 	now := time.Now().UTC().Format(time.RFC3339)
 	result := &RestoreResult{}
 
-	tx, err := db.BeginTx(ctx, nil)
+	conn, rollback, err := beginImmediate(ctx, db, "restore")
 	if err != nil {
-		return nil, fmt.Errorf("quest: restore: begin tx: %w", err)
+		return nil, err
 	}
-	defer func() { _ = tx.Rollback() }()
+	defer conn.Close()
+	committed := false
+	defer rollback(&committed)
 
 	// --- task_status: skip existing (projectID+taskID PK) ---
 	for _, r := range snap.Quest.TaskStatus {
 		var exists int
-		err := tx.QueryRowContext(ctx,
+		err := conn.QueryRowContext(ctx,
 			`SELECT COUNT(*) FROM task_status WHERE project_id = ? AND task_id = ?`,
 			projectID, r.TaskID,
 		).Scan(&exists)
@@ -98,7 +100,7 @@ func Restore(ctx context.Context, db *sql.DB, projectID, snapshotPath string) (*
 		if r.ClaimedAt != "" {
 			claimedAt = sql.NullString{String: r.ClaimedAt, Valid: true}
 		}
-		if _, err := tx.ExecContext(ctx,
+		if _, err := conn.ExecContext(ctx,
 			`INSERT INTO task_status (project_id, task_id, status, claimed_by, claimed_at, updated_at)
 			 VALUES (?, ?, ?, ?, ?, ?)`,
 			projectID, r.TaskID, r.Status, claimedBy, claimedAt, updAt,
@@ -114,7 +116,7 @@ func Restore(ctx context.Context, db *sql.DB, projectID, snapshotPath string) (*
 		if createdAt == "" {
 			createdAt = now
 		}
-		if _, err := tx.ExecContext(ctx,
+		if _, err := conn.ExecContext(ctx,
 			`INSERT INTO task_notes (project_id, task_id, agent_id, note, created_at)
 			 VALUES (?, ?, ?, ?, ?)`,
 			projectID, r.TaskID, r.AgentID, r.Note, createdAt,
@@ -137,7 +139,7 @@ func Restore(ctx context.Context, db *sql.DB, projectID, snapshotPath string) (*
 		if r.Data != "" {
 			data = sql.NullString{String: r.Data, Valid: true}
 		}
-		if _, err := tx.ExecContext(ctx,
+		if _, err := conn.ExecContext(ctx,
 			`INSERT INTO task_events (project_id, task_id, event, agent_id, data, created_at)
 			 VALUES (?, ?, ?, ?, ?, ?)`,
 			projectID, r.TaskID, r.Event, agentID, data, createdAt,
@@ -147,8 +149,9 @@ func Restore(ctx context.Context, db *sql.DB, projectID, snapshotPath string) (*
 		result.EventsImported++
 	}
 
-	if err := tx.Commit(); err != nil {
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
 		return nil, fmt.Errorf("quest: restore: commit: %w", err)
 	}
+	committed = true
 	return result, nil
 }

--- a/internal/quest/summon.go
+++ b/internal/quest/summon.go
@@ -36,9 +36,20 @@ func Summon(ctx context.Context, db *sql.DB, projectID, questID, targetAgent, ca
 	}
 	callerAgent = journalAgent(callerAgent)
 
-	// Verify quest exists.
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+
+	conn, rollback, err := beginImmediate(ctx, db, "summon")
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	committed := false
+	defer rollback(&committed)
+
+	// Verify quest exists inside the pinned transaction so the validation
+	// and the ownership transfer share one serialized view.
 	var existStatus sql.NullString
-	err := db.QueryRowContext(ctx,
+	err = conn.QueryRowContext(ctx,
 		`SELECT status FROM task_status WHERE project_id = ? AND task_id = ?`,
 		projectID, questID,
 	).Scan(&existStatus)
@@ -49,15 +60,7 @@ func Summon(ctx context.Context, db *sql.DB, projectID, questID, targetAgent, ca
 		return fmt.Errorf("quest: summon: probe %s: %w", questID, err)
 	}
 
-	now := time.Now().UTC().Format(time.RFC3339Nano)
-
-	tx, err := db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("quest: summon: begin tx: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
-
-	if _, err := tx.ExecContext(ctx,
+	if _, err := conn.ExecContext(ctx,
 		`UPDATE task_status
 		 SET status = 'in_progress', claimed_by = ?, claimed_at = ?, updated_at = ?
 		 WHERE project_id = ? AND task_id = ?`,
@@ -68,12 +71,13 @@ func Summon(ctx context.Context, db *sql.DB, projectID, questID, targetAgent, ca
 
 	// Emit an "assigned" event: data contains the assignee so Scroll
 	// can show "assigned → <agent>".
-	if err := emitEvent(ctx, tx, projectID, questID, "assigned", callerAgent, targetAgent, now); err != nil {
+	if err := emitEvent(ctx, conn, projectID, questID, "assigned", callerAgent, targetAgent, now); err != nil {
 		return err
 	}
 
-	if err := tx.Commit(); err != nil {
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
 		return fmt.Errorf("quest: summon: commit: %w", err)
 	}
+	committed = true
 	return nil
 }

--- a/internal/quest/tx.go
+++ b/internal/quest/tx.go
@@ -3,72 +3,12 @@ package quest
 import (
 	"context"
 	"database/sql"
-	"fmt"
-	"time"
+
+	"github.com/mathomhaus/guild/internal/storage"
 )
 
-// beginImmediate acquires a dedicated *sql.Conn from db, then issues
-// BEGIN IMMEDIATE with a capped-backoff retry loop.
-//
-// Callers that open a write transaction with BEGIN DEFERRED take a read
-// snapshot the first time they touch the DB. Under concurrent writers this
-// means two goroutines can both read stale state and then overwrite each
-// other's changes (or surface SQLITE_BUSY when the lock finally contends).
-// BEGIN IMMEDIATE serializes writers at lock-acquisition time — no stale
-// snapshot, no mid-tx BUSY from a competing writer.
-//
-// Returns the pinned conn (caller must conn.Close() when done) and a
-// rollback function (caller must call if the commit did not succeed).
-// Callers use the committed bool pattern:
-//
-//	conn, rollback, err := beginImmediate(ctx, db)
-//	if err != nil { return ..., err }
-//	defer conn.Close()
-//	committed := false
-//	defer rollback(&committed)
-//	... writes ...
-//	_, err = conn.ExecContext(ctx, "COMMIT")
-//	if err != nil { return ..., err }
-//	committed = true
+// beginImmediate is the quest-scoped wrapper over storage.BeginImmediate so
+// quest callers get consistent "quest: <op>" error prefixes.
 func beginImmediate(ctx context.Context, db *sql.DB, opName string) (*sql.Conn, func(*bool), error) {
-	conn, err := db.Conn(ctx)
-	if err != nil {
-		return nil, nil, fmt.Errorf("quest: %s: acquire conn: %w", opName, err)
-	}
-
-	const maxAttempts = 20
-	var beginErr error
-	for attempt := range maxAttempts {
-		_, beginErr = conn.ExecContext(ctx, "BEGIN IMMEDIATE")
-		if beginErr == nil {
-			break
-		}
-		if !isBusyErr(beginErr.Error()) {
-			_ = conn.Close()
-			return nil, nil, fmt.Errorf("quest: %s: begin immediate: %w", opName, beginErr)
-		}
-		// Capped linear backoff: 10ms × (attempt+1), max 200ms.
-		base := time.Duration(attempt+1) * 10 * time.Millisecond
-		if base > 200*time.Millisecond {
-			base = 200 * time.Millisecond
-		}
-		select {
-		case <-ctx.Done():
-			_ = conn.Close()
-			return nil, nil, fmt.Errorf("quest: %s: begin immediate: %w", opName, ctx.Err())
-		case <-time.After(base):
-		}
-	}
-	if beginErr != nil {
-		_ = conn.Close()
-		return nil, nil, fmt.Errorf("quest: %s: begin immediate (contended out after %d attempts): %w",
-			opName, maxAttempts, beginErr)
-	}
-
-	rollback := func(committed *bool) { //nolint:contextcheck // rollback must survive caller cancellation
-		if !*committed {
-			_, _ = conn.ExecContext(context.Background(), "ROLLBACK")
-		}
-	}
-	return conn, rollback, nil
+	return storage.BeginImmediate(ctx, db, "quest: "+opName)
 }

--- a/internal/storage/tx.go
+++ b/internal/storage/tx.go
@@ -1,0 +1,74 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// BeginImmediate acquires a dedicated *sql.Conn from db, then issues
+// BEGIN IMMEDIATE with a capped-backoff retry loop.
+//
+// Callers that open a write transaction with BEGIN DEFERRED take a read
+// snapshot the first time they touch the DB. Under concurrent writers this
+// can surface SQLITE_BUSY mid-transaction or let two goroutines derive their
+// writes from stale state. BEGIN IMMEDIATE serializes writers at
+// lock-acquisition time instead.
+//
+// errPrefix should name the calling operation (for example "quest: post").
+// The returned rollback function must be called with the caller's committed
+// flag, and conn.Close() must be deferred by the caller.
+func BeginImmediate(ctx context.Context, db *sql.DB, errPrefix string) (*sql.Conn, func(*bool), error) {
+	if errPrefix == "" {
+		errPrefix = "storage"
+	}
+
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("%s: acquire conn: %w", errPrefix, err)
+	}
+
+	const maxAttempts = 20
+	var beginErr error
+	for attempt := range maxAttempts {
+		_, beginErr = conn.ExecContext(ctx, "BEGIN IMMEDIATE")
+		if beginErr == nil {
+			break
+		}
+		if !isBusyErr(beginErr.Error()) {
+			_ = conn.Close()
+			return nil, nil, fmt.Errorf("%s: begin immediate: %w", errPrefix, beginErr)
+		}
+
+		// Capped linear backoff: 10ms × (attempt+1), max 200ms.
+		base := time.Duration(attempt+1) * 10 * time.Millisecond
+		if base > 200*time.Millisecond {
+			base = 200 * time.Millisecond
+		}
+		select {
+		case <-ctx.Done():
+			_ = conn.Close()
+			return nil, nil, fmt.Errorf("%s: begin immediate: %w", errPrefix, ctx.Err())
+		case <-time.After(base):
+		}
+	}
+	if beginErr != nil {
+		_ = conn.Close()
+		return nil, nil, fmt.Errorf("%s: begin immediate (contended out after %d attempts): %w",
+			errPrefix, maxAttempts, beginErr)
+	}
+
+	rollback := func(committed *bool) { //nolint:contextcheck // rollback must survive caller cancellation
+		if !*committed {
+			_, _ = conn.ExecContext(context.Background(), "ROLLBACK")
+		}
+	}
+	return conn, rollback, nil
+}
+
+func isBusyErr(msg string) bool {
+	return strings.Contains(msg, "SQLITE_BUSY") ||
+		strings.Contains(msg, "database is locked")
+}

--- a/internal/test/concurrency/more_concurrency_test.go
+++ b/internal/test/concurrency/more_concurrency_test.go
@@ -1,0 +1,262 @@
+package concurrency_test
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/mathomhaus/guild/internal/quest"
+)
+
+// Test_ConcurrentSummon_AllTransfersPersist fires N goroutines that each summon
+// a distinct in-progress quest to a new owner. Explicit multi-statement write
+// txs previously risked SQLITE_BUSY under pooled contention; after BEGIN
+// IMMEDIATE all transfers should succeed and persist their final owner.
+func Test_ConcurrentSummon_AllTransfersPersist(t *testing.T) {
+	const n = 20
+
+	db, pid := newTestDB(t)
+	ctx := context.Background()
+
+	quests := make([]*quest.Quest, n)
+	for i := range quests {
+		quests[i] = mustPost(t, db, pid, quest.PostParams{
+			Subject: fmt.Sprintf("summon-target-%d", i),
+		})
+		mustAccept(t, db, pid, quests[i].ID, "owner")
+	}
+
+	errs := make([]error, n)
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := range quests {
+		i := i
+		go func() {
+			defer wg.Done()
+			errs[i] = quest.Summon(ctx, db, pid, quests[i].ID, fmt.Sprintf("agent-%d", i), "owner")
+		}()
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("Summon[%d]: %v", i, err)
+		}
+	}
+	for i, q := range quests {
+		got, err := quest.Load(ctx, db, pid, q.ID)
+		if err != nil {
+			t.Fatalf("Load %s: %v", q.ID, err)
+		}
+		wantOwner := fmt.Sprintf("agent-%d", i)
+		if got.Owner != wantOwner {
+			t.Errorf("%s owner=%q, want %q", q.ID, got.Owner, wantOwner)
+		}
+		if got.Status != quest.StatusInProgress {
+			t.Errorf("%s status=%s, want in_progress", q.ID, got.Status)
+		}
+	}
+}
+
+// Test_ConcurrentEpic_AllWritesPersist fires N goroutines that each apply a
+// distinct epic to a distinct quest. The invariant is simple: every write
+// succeeds and each quest replays its assigned epic without SQLITE_BUSY leaks.
+func Test_ConcurrentEpic_AllWritesPersist(t *testing.T) {
+	const n = 20
+
+	db, pid := newTestDB(t)
+	ctx := context.Background()
+
+	quests := make([]*quest.Quest, n)
+	for i := range quests {
+		quests[i] = mustPost(t, db, pid, quest.PostParams{
+			Subject: fmt.Sprintf("epic-target-%d", i),
+		})
+	}
+
+	errs := make([]error, n)
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := range quests {
+		i := i
+		go func() {
+			defer wg.Done()
+			_, errs[i] = quest.SetEpic(ctx, db, pid, fmt.Sprintf("campaign-%d", i), []string{quests[i].ID})
+		}()
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("SetEpic[%d]: %v", i, err)
+		}
+	}
+	for i, q := range quests {
+		got, err := quest.Load(ctx, db, pid, q.ID)
+		if err != nil {
+			t.Fatalf("Load %s: %v", q.ID, err)
+		}
+		wantEpic := fmt.Sprintf("campaign-%d", i)
+		if got.Epic != wantEpic {
+			t.Errorf("%s epic=%q, want %q", q.ID, got.Epic, wantEpic)
+		}
+	}
+}
+
+// Test_ConcurrentJournal_AllNotesPersist appends N distinct notes to the same
+// quest concurrently. The success condition is no SQLITE_BUSY plus every note
+// visible in Scroll afterward.
+func Test_ConcurrentJournal_AllNotesPersist(t *testing.T) {
+	const n = 20
+
+	db, pid := newTestDB(t)
+	ctx := context.Background()
+	q := mustPost(t, db, pid, quest.PostParams{Subject: "journal-target"})
+
+	texts := make([]string, n)
+	errs := make([]error, n)
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := range n {
+		i := i
+		texts[i] = fmt.Sprintf("journal-note-%d", i)
+		go func() {
+			defer wg.Done()
+			errs[i] = quest.Journal(ctx, db, pid, q.ID, "agent", texts[i])
+		}()
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("Journal[%d]: %v", i, err)
+		}
+	}
+
+	scroll, err := quest.Scroll(ctx, db, pid, q.ID)
+	if err != nil {
+		t.Fatalf("Scroll: %v", err)
+	}
+	seen := map[string]bool{}
+	for _, n := range scroll.Notes {
+		seen[n.Note] = true
+	}
+	for _, text := range texts {
+		if !seen[text] {
+			t.Errorf("missing journal note %q after concurrent writes", text)
+		}
+	}
+}
+
+// Test_ConcurrentCampfire_AllSnapshotsPersist appends N distinct checkpoint
+// snapshots to the same quest concurrently. Each checkpoint note should survive
+// the contention window.
+func Test_ConcurrentCampfire_AllSnapshotsPersist(t *testing.T) {
+	const n = 20
+
+	db, pid := newTestDB(t)
+	ctx := context.Background()
+	q := mustPost(t, db, pid, quest.PostParams{Subject: "campfire-target"})
+
+	errs := make([]error, n)
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := range n {
+		i := i
+		go func() {
+			defer wg.Done()
+			errs[i] = quest.Campfire(ctx, db, pid, q.ID, quest.CampfireParams{
+				Next:  fmt.Sprintf("resume-%d", i),
+				Agent: "agent",
+			})
+		}()
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("Campfire[%d]: %v", i, err)
+		}
+	}
+
+	scroll, err := quest.Scroll(ctx, db, pid, q.ID)
+	if err != nil {
+		t.Fatalf("Scroll: %v", err)
+	}
+	for i := range n {
+		want := fmt.Sprintf("next: resume-%d", i)
+		found := false
+		for _, note := range scroll.Notes {
+			if strings.Contains(note.Note, want) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("missing campfire snapshot containing %q", want)
+		}
+	}
+}
+
+// Test_ConcurrentRestore_IdempotentUnderContention fires N concurrent restore
+// calls for the same snapshot into the same target DB. With a serialized write
+// tx, exactly one caller should import the task_status row and the others
+// should observe it as already present rather than racing into constraint
+// failures.
+func Test_ConcurrentRestore_IdempotentUnderContention(t *testing.T) {
+	const n = 10
+
+	ctx := context.Background()
+
+	srcDB, srcPID := newTestDB(t)
+	mustPost(t, srcDB, srcPID, quest.PostParams{Subject: "restore contention sentinel"})
+
+	snapshotPath := filepath.Join(t.TempDir(), "snapshot.json")
+	if err := quest.Archive(ctx, srcDB, srcPID, snapshotPath); err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+
+	dstDB, dstPID := newTestDB(t)
+	results := make([]*quest.RestoreResult, n)
+	errs := make([]error, n)
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := range n {
+		i := i
+		go func() {
+			defer wg.Done()
+			results[i], errs[i] = quest.Restore(ctx, dstDB, dstPID, snapshotPath)
+		}()
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("Restore[%d]: %v", i, err)
+		}
+	}
+
+	imported := 0
+	for _, r := range results {
+		if r != nil {
+			imported += r.TasksImported
+		}
+	}
+	if imported != 1 {
+		t.Errorf("concurrent restore imported %d tasks total, want exactly 1", imported)
+	}
+
+	var count int
+	if err := dstDB.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM task_status WHERE project_id = ?`,
+		dstPID,
+	).Scan(&count); err != nil {
+		t.Fatalf("count restored tasks: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("restored task_status rows=%d, want 1", count)
+	}
+}


### PR DESCRIPTION
## Summary

- **QUEST-200**: Extract `storage.BeginImmediate` into `internal/storage/tx.go` (capped-backoff retry loop, consistent error prefixes). Thin per-package wrappers in `lore/tx.go` and `quest/tx.go`. Migrate `campfire`, `epic`, `journal`, `restore`, `summon` (quest) and `reforge`, `appraise.bumpAccessCounters` (lore) off plain `BeginTx` to `beginImmediate`.
- **QUEST-201**: Add `canonicalizeProjectFilePath` helper (`internal/lore/path.go`) that resolves relative `file_path` values against the registered project root at write time. Wired into `Inscribe` and lore `Restore` — stored paths are always absolute, making git-aware echoes reads cwd-independent.
- **QUEST-199 (partial)**: Add `lore/concurrency_test.go` (concurrent Reforge pairs + exact supersedes-edge count; concurrent Appraise with exact access-count assertion) and `internal/test/concurrency/more_concurrency_test.go` (Summon, SetEpic, Journal, Campfire, Restore contention tests with note-cardinality and exact-import-count assertions). Shared harness + mixed-writer scenarios + per-kind event-count assertions remain open per QUEST-199 spec.

## Quests closed

- QUEST-200 — shared `BeginImmediate` helper and migration of remaining write paths
- QUEST-201 — `canonicalizeProjectFilePath` wired into `Inscribe` + lore `Restore`

## Quests partially addressed (left open)

- QUEST-199 — concurrency tests added with cardinality assertions; shared harness, mixed-writer tests, and per-kind event-count assertions per spec remain

## Risk notes

- `storage.BeginImmediate` duplicates the `isBusyErr` string-match from `accept.go` — both are unexported and in separate packages, no collision. Could be deduped as a follow-up.
- `catalog.go` uses `filepath.Abs` (not `canonicalizeProjectFilePath`) — already produces absolute paths, no gap.
- `update.go` has no `FilePath` field — correctly unchanged.

## Test plan

- [ ] `make check` passes (fmt + vet + lint + sqlcheck + race tests)
- [ ] `go test -race ./internal/test/concurrency/...` — all new Summon/Epic/Journal/Campfire/Restore contention tests green
- [ ] `go test -race ./internal/lore/...` — new Reforge concurrent pairs + access-counter bump tests green
- [ ] `go test -race ./internal/quest/...` — no regressions