### PR TITLE
docs(onboarding): README 'first 10 minutes' + seeding-principles + docs-to-lore examples (QUEST-203)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,86 @@ The agent takes it from there, including all subsequent sessions.
 
 See a few [`examples/`](./examples/) of what guild can do. All small scenarios, each under 5 minutes.
 
+## Your first 10 minutes with guild
+
+You have just run `guild init`. Here is what to do next.
+
+**What is "lore"?** Lore is guild's persistent knowledge archive. Entries
+are typed by kind: `principle` (a behavioral rule), `research` (findings),
+`decision` (a choice and its rationale), `observation` (something noticed),
+or `idea` (a seed thought). Lore entries outlive sessions and are searchable.
+
+**What is "the oath"?** The oath is the subset of lore where `kind=principle`.
+Every `guild_session_start` call automatically loads all current principles
+for the active project and delivers them to the agent. The agent starts bound
+by those principles without any additional prompting. You write them once;
+they fire every session.
+
+**What is an MCP tool?** MCP (Model Context Protocol) is the standard
+protocol most AI coding tools use to expose server-side capabilities. Guild
+ships as an MCP server, so tools like `lore_inscribe` and `quest_post` are
+callable directly from your agent without any additional setup after
+`guild init` runs.
+
+### Step 1: Seed a principle
+
+Open your project in your MCP-enabled editor and tell the agent:
+
+> "Inscribe a principle: in this codebase, prefer table-driven tests in Go.
+> Use kind=principle, topic=testing."
+
+The agent will call `lore_inscribe`. You will see a confirmation like:
+
+```
+📜 inscribed LORE-1: prefer table-driven tests in Go [principle]
+```
+
+That is the oath growing. The next session, the agent starts knowing this
+convention.
+
+### Step 2: File a task
+
+Tell the agent:
+
+> "Post a quest: audit existing test files for non-table-driven tests."
+
+The agent calls `quest_post`. You will see:
+
+```
+➕ posted QUEST-1: audit existing test files for non-table-driven tests
+```
+
+### Step 3: Start a new session
+
+Close the chat. Reopen it. Tell the agent: "start a guild session."
+
+The agent calls `guild_session_start`. The response will show:
+
+```
+⚔️ 1 oath(s) sworn:
+  prefer table-driven tests in Go — ...
+
+🎯 top bounty:
+  QUEST-1 [P2] audit existing test files for non-table-driven tests
+```
+
+The principle auto-loaded. The quest surfaced. You typed nothing.
+
+### Ready to go further?
+
+Two patterns that compound guild's value quickly, once principles and tasks
+are flowing:
+
+- **[Seeding principles](./examples/seeding-principles.md)**: five concrete
+  principle shapes (code-style, domain convention, workflow, never-do rule,
+  tool preference) with before/after narratives.
+- **[Docs to lore](./examples/docs-to-lore.md)**: turning an existing docs
+  directory into a queryable corpus. Includes an honest explanation of how
+  retrieval works (BM25 keyword search, not semantic embeddings) and the
+  failure modes to avoid.
+
+---
+
 ## ⚔️ A full session
 
 The three-act flow an agent runs on its own every time it wakes.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,16 +1,29 @@
 # Examples
 
-Each example shows one thing guild can do for a specific user need. Mix and match however your own process demands — guild is un-opinionated about *how* you work; these examples show *what it can do*.
+Each example shows one thing guild can do for a specific user need. Mix and
+match however your own process demands. Guild is un-opinionated about *how*
+you work; these examples show *what it can do*.
 
 ## Minimum bootstrap
 
-To get value from guild, you need two calls: `session_start` at the beginning, `quest_brief` at the end. Everything between is opt-in.
+To get value from guild, you need two calls: `session_start` at the
+beginning, `quest_brief` at the end. Everything between is opt-in.
 
-## What do you want to do?
+## Start here
+
+Two patterns that unlock immediate value once guild is installed. Read these
+first; they compound with everything else.
 
 | I want to... | See |
 |---|---|
-| Get started after installing guild | [01-hello-guild](./01-hello-guild/) |
+| Make agent conventions stick across sessions (stop repeating yourself) | [seeding-principles.md](./seeding-principles.md) |
+| Make my existing docs queryable by an agent | [docs-to-lore.md](./docs-to-lore.md) |
+
+## Beyond the basics
+
+| I want to... | See |
+|---|---|
+| Get started with a runnable cold-start scenario | [01-hello-guild](./01-hello-guild/) |
 | Break a big planning task across parallel subagents without collisions | [02-quest-decomposition](./02-quest-decomposition/) |
 | Pull context from a previous project into a new one | [03-cross-project](./03-cross-project/) |
 | Hand off mid-task to tomorrow-me (or another agent) | [04-session-handoff](./04-session-handoff/) |
@@ -18,34 +31,51 @@ To get value from guild, you need two calls: `session_start` at the beginning, `
 
 ## The grand tour
 
-Each example stands alone — read them in any order. But if you want to see how guild's value compounds as you adopt more of it, read in this order:
+Each example stands alone. Read them in any order. But if you want to see
+how guild's value compounds as you adopt more of it, read in this order:
 
-1. **[01 hello-guild](./01-hello-guild/)** — guild remembers things within a session
-2. **[04 session-handoff](./04-session-handoff/)** — ...and across time
-3. **[03 cross-project](./03-cross-project/)** — ...and across projects
-4. **[02 quest-decomposition](./02-quest-decomposition/)** — ...and can coordinate multiple agents at once
-5. **[05 lore-only](./05-lore-only/)** — ...or strip it back to just a notebook, if that's all you need
+1. **[seeding-principles](./seeding-principles.md)**: conventions that
+   apply from the first session
+2. **[docs-to-lore](./docs-to-lore.md)**: docs become agent-queryable
+3. **[01 hello-guild](./01-hello-guild/)**: guild remembers things within a session
+4. **[04 session-handoff](./04-session-handoff/)**: ...and across time
+5. **[03 cross-project](./03-cross-project/)**: ...and across projects
+6. **[02 quest-decomposition](./02-quest-decomposition/)**: ...and can coordinate multiple agents at once
+7. **[05 lore-only](./05-lore-only/)**: ...or strip it back to just a notebook, if that's all you need
 
-Each arrow adds one axis of value; none require the previous example as a prerequisite.
+Each entry adds one axis of value; none require the previous as a
+prerequisite.
 
-## How each example is structured
+## How each numbered example is structured
 
-Every example directory contains:
+Every numbered example directory contains:
 
-- **`README.md`** — scenario narrative and what it demonstrates
-- **`PROMPT.md`** — a paste-ready prompt for your MCP-enabled agent
-- **`expected/`** — captured output snapshots (quest list, lore catalog, brief) so you can see what guild produces without running anything
-- **`setup.sh`** / **`teardown.sh`** — sandbox init + cleanup (creates a distinctly-named guild project so the example doesn't pollute your real board)
+- **`README.md`**: scenario narrative and what it demonstrates
+- **`PROMPT.md`**: a paste-ready prompt for your MCP-enabled agent
+- **`expected/`**: captured output snapshots (quest list, lore catalog, brief)
+  so you can see what guild produces without running anything
+- **`setup.sh`** / **`teardown.sh`**: sandbox init + cleanup (creates a
+  distinctly-named guild project so the example doesn't pollute your real board)
+
+The two new entries (`seeding-principles.md` and `docs-to-lore.md`) are
+read-only conceptual guides; they don't have setup/teardown scripts.
 
 ## How to engage
 
-- **Skim** — read `README.md` + `expected/` to see what guild produces without touching it
-- **Run it** — `./setup.sh`, paste `PROMPT.md` into your MCP client, `./teardown.sh` when done
+- **Skim**: read `README.md` + `expected/` to see what guild produces without
+  touching it
+- **Run it**: `./setup.sh`, paste `PROMPT.md` into your MCP client,
+  `./teardown.sh` when done
 
-> The `guild` CLI drives the same `~/.guild/*.db` state as the MCP tools — useful for scripting or CI. These examples use the agent-driven path because that's how users work day-to-day.
+> The `guild` CLI drives the same `~/.guild/*.db` state as the MCP tools,
+> useful for scripting or CI. These examples use the agent-driven path
+> because that is how users work day-to-day.
 
 ## Sandbox isolation
 
-Each example initializes a distinctly-named project (e.g. `guild-example-01-hello-guild`) in your real `~/.guild/*.db`, contained to that project. Run `./teardown.sh` to clean up afterward.
+Each numbered example initializes a distinctly-named project (e.g.
+`guild-example-01-hello-guild`) in your real `~/.guild/*.db`, contained to
+that project. Run `./teardown.sh` to clean up afterward.
 
-> ⚠️ **Teardown is currently best-effort.** Clean single-project wipe is tracked at QUEST-152 (lore strike / quest strike) and QUEST-153 (guild raze). Until those land, teardown is a multi-step delete dance.
+> Teardown is currently best-effort. Clean single-project wipe is tracked
+> separately. Until that lands, teardown is a multi-step delete dance.

--- a/examples/docs-to-lore.md
+++ b/examples/docs-to-lore.md
@@ -1,0 +1,280 @@
+# Docs to Lore
+
+> *"I already have a bunch of design docs and runbooks. Can guild make them queryable?"*
+
+You have a directory of Markdown notes: auth design, deploy runbook, data
+model, ADRs. Right now they are readable but not queryable by an agent. You
+want to turn that corpus into a project-specific retrieval layer so an agent
+can find relevant context with `lore_appraise` before it starts writing code.
+
+## What this example shows
+
+- How to turn existing documentation into lore entries an agent can search
+- The correct shape for a lore entry used as a doc pointer: distilled
+  summary, keyword-rich tags, source path pointing back to the original file
+- How the retrieval actually works under the hood (important: read before
+  setting expectations)
+- Common failure modes and how to fix them
+
+This example is read-only (conceptual plus live output). It shows the
+pattern, not a runnable scenario. For a runnable example with setup and
+teardown, see [01-hello-guild](./01-hello-guild/).
+
+## Primitives used
+
+| Primitive | Role |
+|---|---|
+| `lore_inscribe` | Write one entry per doc; distilled summary + tags + source path |
+| `lore_appraise` | Query the corpus by keyword; BM25 ranked results |
+| `lore_study` | Fetch full entry detail (summary, tags, source path) |
+
+## How retrieval works (read this first)
+
+Guild's retrieval is SQLite FTS5 with BM25 ranking over three columns:
+`title`, `summary`, and `tags`. This is defined in
+`internal/storage/migrations/001_init.up.sql:67-70` and used in
+`internal/lore/appraise.go:245`. There are no embeddings, no vectors, no
+semantic similarity.
+
+That means:
+
+- **Lexical, not semantic.** "car" will not match "automobile". Keyword
+  overlap between the query and the indexed fields is required to surface
+  a result.
+- **Three indexed fields.** Only `title`, `summary`, and `tags` are in the
+  FTS index. The `source` field (the path back to your original doc) is
+  stored on the entry but is not searchable. The body/rationale field on a
+  lore entry is also outside the FTS index; it is retrievable via
+  `lore_study` (progressive disclosure) but invisible to `lore_appraise`.
+- **The searchable surface is the distilled metadata.** This is the whole
+  trick: each doc's title, a 2-3 sentence summary written in the terminology
+  users naturally query with, and a tag list that bridges vocabulary gaps.
+
+One user who tried the pattern put it this way: "now it became a little RAG
+system almost." The "almost" is doing real work. Guild is *lexical* RAG
+(the same family as Elasticsearch or Lucene BM25 search), not *semantic*
+RAG (not the same family as OpenAI-embeddings search or a vector database).
+Queries that match on shared keywords retrieve well. Queries that rely on
+concept synonymy do not, unless the tags bridge the gap.
+
+The implication for how you inscribe entries is direct: tags are the
+vocabulary bridge. If a user might query "login expiry" but the doc uses
+"JWT refresh window", the entry needs both sets of terms in its tags.
+
+## Walkthrough
+
+Start with a directory of docs:
+
+```
+~/projects/myapp/docs/
+  auth-design.md
+  deploy-runbook.md
+  data-model.md
+```
+
+### Option A: agent-inscribed (recommended)
+
+Tell your agent to inscribe each doc with a distilled summary and rich tags.
+The prompt that works well in practice:
+
+```
+For each Markdown file in docs/, inscribe a lore entry.
+For each doc:
+- Write a distinct 2-3 sentence summary in the terminology a developer would
+  naturally use to query this topic. Do NOT paste the full doc body.
+- Choose an appropriate kind (research for design docs, decision for ADRs,
+  observation for runbooks).
+- Add keyword-rich tags including synonyms a user might query with.
+- Set source to the absolute file path.
+- Set topic to a short slug matching the doc's domain.
+```
+
+What the agent produces for `auth-design.md`:
+
+```
+lore_appraise(query="authentication JWT token refresh")
+# → nothing found
+
+lore_inscribe(
+  kind="research",
+  title="auth-design: JWT token lifecycle",
+  summary="JWTs expire at 1 hour; clients must refresh before expiry. Refresh window opens at 55 minutes to avoid race conditions. Refresh tokens rotate on each use and are stored in httpOnly cookies.",
+  topic="auth",
+  tags=["auth", "authentication", "jwt", "token", "refresh", "expiry",
+        "login", "session", "cookie", "httponly"],
+  source="~/projects/myapp/docs/auth-design.md"
+)
+```
+
+Note: the summary is a distillation, not a paste of the doc. The tags
+include synonyms (`authentication` alongside `auth`, `login` alongside
+`session`) to bridge the vocabulary gap.
+
+After inscribing all three docs:
+
+```
+$ guild lore list --project myapp
+
+📜 3 entry(ies):
+  LORE-1  [research · current]  auth-design: JWT token lifecycle
+  LORE-2  [research · current]  data-model: core entities and soft-delete
+  LORE-3  [research · current]  deploy-runbook: ECS rolling deploy and rollback
+```
+
+### Option B: guild lore catalog (fast, lower fidelity)
+
+`guild lore catalog <dir>` bulk-imports Markdown files automatically.
+Each file's title becomes the entry title; the file content becomes the
+summary; the file stem becomes the topic.
+
+```
+$ guild lore catalog ~/projects/myapp/docs \
+    --project myapp \
+    --kind research
+
+📚 cataloged: imported=3 skipped=0
+```
+
+This is fast but lower fidelity: the summary is the raw file body, not a
+distillation. Tags are empty unless you pass `--tags`. Retrieval quality
+degrades when summaries are long unstructured prose rather than
+keyword-dense sentences. Start with catalog to bootstrap, then update
+entries with `lore_update` (or re-inscribe with distilled summaries) as
+you notice retrieval gaps.
+
+## Live retrieval output
+
+The following is captured from the live binary (guild v0.2.1) after
+inscribing the three entries with the agent-inscribed approach above:
+
+```
+$ guild lore appraise "token refresh" --project myapp
+
+🔮 1 entry(ies) appraised:
+
+  LORE-1  [research · current · today]
+  auth-design: JWT token lifecycle
+  JWTs expire at 1 hour; clients must refresh before expiry. Refresh window
+  opens at 55 minutes to avoid race conditions. Refresh tokens rotate on
+  each use and are stored in httpOnly cookies.
+  tags: auth,authentication,jwt,token,refresh,expiry,login,session,cookie,httponly
+  source: ~/projects/myapp/docs/auth-design.md
+```
+
+```
+$ guild lore appraise "deploy rollback" --project myapp
+
+🔮 1 entry(ies) appraised:
+
+  LORE-3  [research · current · today]
+  deploy-runbook: ECS rolling deploy and rollback
+  ...
+```
+
+**Vocabulary gap in action.** After importing with `catalog` (raw content,
+no synonym tags), querying "login expiry" returns nothing even though the
+auth doc covers exactly that:
+
+```
+$ guild lore appraise "login expiry" --project myapp
+🔮 nothing found for "login expiry" — research needed
+```
+
+After re-inscribing with distilled summary and synonym tags (`login`,
+`expiry`, `authentication`), the same query hits:
+
+```
+$ guild lore appraise "login expiry" --project myapp
+
+🔮 1 entry(ies) appraised:
+
+  LORE-1  [research · current · today]
+  auth-design: JWT token lifecycle
+  ...
+  tags: auth,authentication,jwt,token,refresh,expiry,login,session,...
+```
+
+The tag `login` is what closed the gap. The summary alone did not contain
+the word "login".
+
+## Common failure modes
+
+### 1. Pasting the full doc body into summary
+
+The temptation is to put the whole Markdown file into `summary` so
+"everything" is searchable. This has three problems.
+
+First, it violates the 2-3 sentence principle. The `principle-too-long`
+hint in the hints engine will fire and tell you.
+
+Second, it does not make the whole body searchable in a useful way. FTS5
+tokenizes and indexes the entire summary field, so a very long summary does
+rank on its terms, but BM25 scoring degrades when the summary is full of
+prose instead of keyword-dense sentences. Ranking quality drops and
+unrelated results start surfacing.
+
+Third, lore entries are the query layer, not the storage layer. The
+original file is the canonical source. The entry's `source` field points
+back to it. Use `lore_study` to retrieve the full file path and then read
+the file. Pasting the body defeats this design and creates a maintenance
+problem: now you have two copies of the content to keep in sync.
+
+**Fix:** write a 2-3 sentence distillation. Store the file path in
+`source`. Read the full content via the file when an agent needs it.
+
+### 2. Expecting semantic similarity
+
+If you query "vehicle performance" expecting to find docs about "car
+latency benchmarks", you will be disappointed. There are no embeddings.
+Guild does not know that "vehicle" and "car" are related. Retrieval is
+exact token overlap after FTS5 normalization (lowercasing, stemming).
+
+**Fix:** add synonym tags. If the doc uses "car" and users ask about
+"vehicle", add both as tags: `["car", "vehicle", "automobile",
+"benchmark", "performance", "latency"]`. This is the explicit vocabulary
+bridge that replaces the implicit vocabulary bridge a semantic search
+system would provide.
+
+If your retrieval is consistently disappointing, inspect BM25 scores with
+`--verbose` (planned for a future release; today: check `guild lore study
+<ID>` to see the full entry and verify tags are set correctly).
+
+### 3. Retrieval disappointing after catalog import
+
+`catalog` imports produce empty tag fields and full-body summaries. Both
+hurt retrieval quality. The quick fix is to update the high-value entries
+with `lore_update` (add tags, shorten summary to 2-3 sentences) or
+re-inscribe them properly and `lore seal` the imported versions.
+
+### 4. Source paths become stale
+
+If you move or rename the source doc, the `source` field on the lore entry
+still points to the old path. Guild does not track file renames. Update the
+entry with `lore_update` after a doc move, or re-inscribe.
+
+## What an agent does with this
+
+Once the corpus is inscribed, an agent working on a feature that touches
+authentication would start by calling:
+
+```
+lore_appraise(query="auth JWT token", all_projects=True)
+```
+
+Guild returns the auth-design entry. The agent reads the summary, sees the
+source path, and can read the full file if it needs implementation details.
+The agent has project-specific context before writing a single line of code,
+without requiring a human to provide it manually each session.
+
+That is the pattern: docs stay in the source tree as the authoritative
+reference; lore entries are the queryable index that makes them discoverable.
+
+## See also
+
+- [seeding-principles.md](./seeding-principles.md): a complementary
+  pattern: inscribing behavioral conventions (not doc pointers) as
+  principles that auto-load on every session
+- [05-lore-only](./05-lore-only/): using guild purely as a knowledge layer
+  without any quest ceremony
+- [01-hello-guild](./01-hello-guild/): runnable cold-start example that
+  shows the appraise-before-inscribe discipline

--- a/examples/seeding-principles.md
+++ b/examples/seeding-principles.md
@@ -1,0 +1,208 @@
+# Seeding Principles
+
+> *"I keep correcting the same agent mistakes. How do I make them stick?"*
+
+You have a project convention the team follows religiously: table-driven
+tests in Go, a specific AWS auth helper, no em dashes in generated text,
+and a domain architecture rule. You are tired of restating these every
+session. Inscribe them as principles once and every future session loads
+them automatically, without a prompt.
+
+## What this example shows
+
+- How to inscribe project-specific conventions as `kind=principle` lore entries
+- How the oath wall (the auto-loaded set of principles) shapes agent behavior
+  from session start, without repeating yourself
+- Five principle shapes: code-style, domain convention, workflow preference,
+  never-do rule, and tool preference
+- The 60-word discipline: principles longer than 60 words belong in a
+  `kind=decision` entry; the principle just points there
+
+This example is read-only (conceptual). It shows the pattern, not a
+runnable scenario. For a runnable end-to-end, see
+[01-hello-guild](./01-hello-guild/).
+
+## Primitives used
+
+| Primitive | Role |
+|---|---|
+| `lore_inscribe(kind=principle)` | Write a rule that auto-loads every future session |
+| `lore_appraise` | Check for duplicates before inscribing |
+| `guild_session_start` | Loads the oath wall; all principles surface here |
+
+## How principles become oath
+
+When you call `guild_session_start`, guild loads every `kind=principle`
+entry (status=current) for the active project and delivers them to the
+agent before any tool call. The agent starts bound by them. This is the
+oath.
+
+There is nothing else to configure. Inscribe a principle once; it fires
+on every future session for that project.
+
+## The 60-word bar
+
+A principle auto-loads every session. That has a cost: every token in
+the principle is paid by every future agent, forever. So the bar is
+tight: if a principle needs more than 60 words to express, it's a
+decision in disguise. Inscribe the rationale as `kind=decision`, then
+write a short principle that references it.
+
+## Example 1: code-style
+
+**Convention:** Go tests use table-driven style.
+
+```
+lore_appraise(query="Go testing style")
+# → nothing found
+
+lore_inscribe(
+  kind="principle",
+  title="prefer table-driven tests in Go",
+  summary="Go tests use table-driven style: define a slice of structs (name, input, want), range over them, call t.Run. Subtests are named. Avoids test-per-variant function sprawl.",
+  topic="testing",
+  tags=["go", "testing", "table-driven", "code-style"]
+)
+```
+
+**Without the principle:** an agent writes one test function per case,
+named `TestFooReturnsBarOnInput1`, `TestFooReturnsBarOnInput2`. Valid Go,
+but not the project convention.
+
+**With the principle:** the agent writes a single `TestFoo` function with
+a `cases` slice and a `for _, tc := range cases { t.Run(tc.name, ...) }`
+loop. No prompt needed.
+
+What the oath shows next session:
+```
+⚔️ 1 oath(s):
+  prefer table-driven tests in Go — Go tests use table-driven style:
+  define a slice of structs (name, input, want), range over them, call
+  t.Run. Subtests are named. Avoids test-per-variant function sprawl.
+```
+
+## Example 2: domain convention
+
+**Convention:** this codebase follows hexagonal architecture; the domain
+layer must stay free of infrastructure imports.
+
+```
+lore_inscribe(
+  kind="principle",
+  title="hexagonal architecture: keep domain layer free of infra imports",
+  summary="The domain package (internal/domain) must not import infra packages (internal/storage, internal/http, external SDKs). Adapters live in internal/adapters. Violations break the dependency inversion that makes the domain testable without mocks.",
+  topic="architecture",
+  tags=["hexagonal", "domain", "architecture", "infra", "dependency-inversion"]
+)
+```
+
+**Without the principle:** an agent adds a database call directly inside a
+domain type to satisfy a feature request. It compiles. It breaks the
+architecture contract.
+
+**With the principle:** the agent routes the change through an adapter,
+keeps the domain pure, and adds a port interface if none exists. The
+convention holds without a code-review reminder.
+
+## Example 3: workflow preference
+
+**Convention:** always run `make check` before calling a task done.
+
+```
+lore_inscribe(
+  kind="principle",
+  title="run make check before calling a task done",
+  summary="Always run make check (fmt + vet + lint + sqlcheck + test-race) before marking any quest fulfilled. A green CI gate is the definition of done for this repo.",
+  topic="workflow",
+  tags=["workflow", "make", "check", "done-criteria", "ci"]
+)
+```
+
+**Without the principle:** an agent fulfills a quest after the unit tests
+pass locally, but the linter catches a format issue in CI and the PR fails.
+
+**With the principle:** the agent runs `make check` before writing the
+fulfillment report and catches the issue before the PR is opened.
+
+## Example 4: never-do rule
+
+**Convention:** no em dashes in any generated artifact.
+
+```
+lore_inscribe(
+  kind="principle",
+  title="no em dashes in generated text",
+  summary="Never output the em dash character in any artifact: commits, PR bodies, code comments, docs. Use a period, comma, parentheses, or colon instead. Applies to every tool call in every session.",
+  topic="style",
+  tags=["style", "formatting", "em-dash", "never-do", "punctuation"]
+)
+```
+
+**Without the principle:** an agent writes "we shipped the feature; it is
+now in production" with an em dash. The commit passes review but violates
+the house rule.
+
+**With the principle:** the agent uses a semicolon or splits into two
+sentences. The rule fires from the oath wall before the agent writes a
+single word.
+
+This particular principle is self-dogfooding: the guild repo itself uses
+it (see `examples/01-hello-guild/` for the original scenario it came from).
+
+## Example 5: tool preference
+
+**Convention:** use `keyconjurer` for AWS credential vending, not
+`aws configure` or hardcoded keys.
+
+```
+lore_inscribe(
+  kind="principle",
+  title="use keyconjurer for AWS auth, not aws configure",
+  summary="Obtain AWS credentials via keyconjurer (keyconjurer get <role>), not aws configure or hardcoded keys. Keyconjurer enforces SSO and short-lived credentials. Storing long-lived keys in ~/.aws/credentials is a security violation on this team.",
+  topic="aws",
+  tags=["aws", "auth", "keyconjurer", "credentials", "security", "sso", "tool-preference"]
+)
+```
+
+**Without the principle:** an agent scaffolds an AWS SDK integration and
+adds `aws configure` instructions to the setup docs, or worse, suggests
+hardcoding an access key for local testing.
+
+**With the principle:** the agent generates a `keyconjurer get
+<role>` step in the setup instructions and warns against long-lived
+credential storage. No human follow-up needed.
+
+## Live output reference
+
+The following is captured from the live binary (guild v0.2.1). After
+inscribing the three principles from above:
+
+```
+$ guild lore oath --project myapp
+
+⚔️ 3 oath(s):
+  no em dashes in generated text — Never output the em dash character (—)
+  in any artifact: commits, PR bodies, code comments, docs. Use a period,
+  comma, parentheses, or colon instead. Applies to every tool call in
+  every session.
+
+  prefer table-driven tests in Go — Go tests use table-driven style:
+  define a slice of structs (name, input, want), range over them, call
+  t.Run. Subtests are named. Avoids test-per-variant function sprawl.
+
+  run make check before calling a task done — Always run make check
+  (fmt + vet + lint + sqlcheck + test-race) before marking any quest
+  fulfilled. A green CI gate is the definition of done for this repo.
+```
+
+The same three lines appear in `guild_session_start` output under
+`oath(s) sworn` when a session opens on this project.
+
+## See also
+
+- [docs-to-lore.md](./docs-to-lore.md): turning existing documentation
+  into a queryable lore corpus
+- [01-hello-guild](./01-hello-guild/): runnable cold-start example that
+  inscribes a principle and shows the oath feedback loop
+- [04-session-handoff](./04-session-handoff/): how principles and briefs
+  compound across sessions


### PR DESCRIPTION
## Summary

- **README**: new "Your first 10 minutes with guild" section immediately after Quick Start, with inline glosses for MCP, oath, and lore kinds; links forward to both new examples
- **examples/seeding-principles.md**: five concrete principle shapes (code-style, domain convention, workflow preference, never-do rule, tool preference) with `lore_inscribe` calls and before/after narratives per shape; live oath-wall output from guild v0.2.1
- **examples/docs-to-lore.md**: docs-to-lore pattern with a mandatory mechanics section naming SQLite FTS5 + BM25 ranking, indexed fields (title + summary + tags), body-not-indexed distinction, lexical vs semantic boundary, vocabulary-gap calibration, and a common failure modes section; verbatim user quote ("now it became a little RAG system almost") with surrounding explanation; live binary output for both a hit and a vocabulary-gap miss
- **examples/README.md**: re-ordered so the two new entries lead under "Start here"; numbered examples move under "Beyond the basics"

All CLI commands verified against the installed binary (guild v0.2.1). `make check` passes.

## Closes

QUEST-203

## Test plan

- [ ] Read README "Your first 10 minutes" section: MCP, oath, and lore kinds are glossed on first use; no unexplained jargon
- [ ] Read examples/seeding-principles.md: five distinct principle shapes are present; each has an `lore_inscribe` call, a before-state, and an after-state
- [ ] Read examples/docs-to-lore.md: mechanics section names FTS5, BM25, indexed fields (title + summary + tags), body-not-indexed; "car / automobile" style calibration present; user quote present verbatim; failure modes section covers paste-full-doc, semantic expectation, catalog-import quality
- [ ] Read examples/README.md: seeding-principles and docs-to-lore are listed first under "Start here"; numbered examples appear under "Beyond the basics"
- [ ] Grep new files for em dash character (—): should appear only inside code-block terminal output, not in prose
- [ ] Run `make check` from repo root: passes