### PR TITLE
fix(release): mkdir -p platform asset dirs in assets-model for fresh CI checkouts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -257,6 +257,7 @@ assets-model: ## Copy model.onnx + vocab.txt into every platform subdir (uses AS
 	  src="$(MODEL_CACHE)"; \
 	fi; \
 	for triple in darwin_arm64 darwin_amd64 linux_amd64 linux_arm64; do \
+	  mkdir -p $(ASSETS_DIR)/$$triple; \
 	  cp "$$src/model.onnx" $(ASSETS_DIR)/$$triple/model.onnx; \
 	  cp "$$src/vocab.txt"  $(ASSETS_DIR)/$$triple/vocab.txt; \
 	done


### PR DESCRIPTION
## Summary

The `assets-model` Makefile target's `cp` loop assumed the per-platform asset subdirs (`internal/lore/embed/assets/{darwin,linux}_{amd64,arm64}`) already existed. They exist on the maintainer's machine because the spike created them, but they're not tracked in git (only `.gitignore` and `README.md` are), so a fresh CI checkout doesn't have them.

## Symptom

`v0.3.1` release pipeline failed at the "Stage model assets from pinned release" step:
```
cp: cannot create regular file 'internal/lore/embed/assets/darwin_arm64/model.onnx': No such file or directory
make: *** [Makefile:230: assets-model] Error 1
```

(See run https://github.com/mathomhaus/guild/actions/runs/24923566300/job/72989460062.)

## Fix

Single line: add `mkdir -p $(ASSETS_DIR)/$$triple` inside the cp loop, before each `cp` invocation. Idempotent on the maintainer's machine (dirs already exist) and self-healing on fresh CI checkouts.

The parent `assets:` target already does this mkdir, but `release.yml` calls `make assets-model` directly to skip the `assets-runtime` ORT-download step (which goreleaser handles via its own `before.hooks`). Folding mkdir into `assets-model` itself makes the target idempotent regardless of caller.

## Test plan

- [x] Local: ran `rm -rf internal/lore/embed/assets/{darwin,linux}_{amd64,arm64}` and `make assets-model` from a clean state. Subdirs created, model.onnx + vocab.txt staged.
- [ ] After merge: re-tag `v0.3.1` on the new HEAD; release.yml run should pass the staging step cleanly.