### PR TITLE
perf(lore): cache repo-root lookup in defaultGitFileLastModified (#50)

### DIFF
--- a/internal/lore/echoes.go
+++ b/internal/lore/echoes.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -45,6 +46,14 @@ func Echoes(ctx context.Context, db *sql.DB, project string, gitAware bool) ([]E
 	defer func() { _ = rows.Close() }()
 
 	now := time.Now().UTC()
+	// Per-batch repo-root cache. Without it defaultGitFileLastModified
+	// shells out to `git rev-parse --show-toplevel` once per entry, so a
+	// list of N entries in the same repo costs 2N subprocess spawns
+	// instead of N+1. The resolver lives only for this Echoes call so
+	// state cannot leak between batches or across repos.
+	if gitAware {
+		ctx = withRepoRootResolver(ctx, newRepoRootResolver())
+	}
 	var stale []Echo
 	for rows.Next() {
 		e := &Entry{}
@@ -104,16 +113,14 @@ func defaultGitFileLastModified(ctx context.Context, path string) time.Time {
 
 	// Derive the repository root from the file's own directory so the
 	// query is never sensitive to the guild process's ambient CWD.
+	// Use the per-batch resolver if Echoes installed one, otherwise
+	// fall back to a one-shot subprocess (preserves single-call usage).
 	dir := filepath.Dir(path)
-	//nolint:gosec // arguments are hard-coded + file path from DB
-	repoRootCmd := exec.CommandContext(cmdCtx, "git", "rev-parse", "--show-toplevel")
-	repoRootCmd.Dir = dir
-	repoRootOut, err := repoRootCmd.Output()
-	if err != nil {
+	repoRoot := resolveRepoRoot(cmdCtx, dir)
+	if repoRoot == "" {
 		// git missing, not a repo, or dir doesn't exist — degrade quietly.
 		return time.Time{}
 	}
-	repoRoot := strings.TrimSpace(string(repoRootOut))
 
 	//nolint:gosec // arguments are hard-coded + file path from DB
 	cmd := exec.CommandContext(cmdCtx, "git", "log", "-1", "--format=%aI", "--", path)
@@ -127,4 +134,78 @@ func defaultGitFileLastModified(ctx context.Context, path string) time.Time {
 		return time.Time{}
 	}
 	return parseSQLiteTime(s)
+}
+
+// repoRootResolver memoizes `git rev-parse --show-toplevel` results
+// across calls within a single Echoes() pass. Without it a list of N
+// entries in the same repo costs 2N subprocess spawns instead of N+1.
+//
+// The lookup function is injected so tests can verify the cache
+// behaviour without invoking real git or a real filesystem.
+type repoRootResolver struct {
+	mu     sync.Mutex
+	cache  map[string]string // dir -> repo root, "" when dir is not in a repo
+	lookup func(ctx context.Context, dir string) string
+}
+
+func newRepoRootResolver() *repoRootResolver {
+	return &repoRootResolver{
+		cache:  map[string]string{},
+		lookup: defaultRepoRootLookup,
+	}
+}
+
+// Resolve returns the git repo root for dir, using the injected
+// lookup the first time and a cached value on subsequent calls.
+// An empty string is itself a cache entry, so a non-repo directory
+// only spawns one subprocess across the batch.
+func (r *repoRootResolver) Resolve(ctx context.Context, dir string) string {
+	r.mu.Lock()
+	if cached, ok := r.cache[dir]; ok {
+		r.mu.Unlock()
+		return cached
+	}
+	r.mu.Unlock()
+
+	root := r.lookup(ctx, dir)
+
+	r.mu.Lock()
+	r.cache[dir] = root
+	r.mu.Unlock()
+	return root
+}
+
+// defaultRepoRootLookup is the production implementation: shell out to
+// `git rev-parse --show-toplevel` with the directory as the cwd.
+// Returns "" on any error so the caller can degrade quietly.
+func defaultRepoRootLookup(ctx context.Context, dir string) string {
+	//nolint:gosec // arguments are hard-coded + dir is derived from a DB-stored file path
+	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--show-toplevel")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+type repoRootResolverKey struct{}
+
+// withRepoRootResolver attaches a per-batch resolver to ctx. Echoes
+// installs one before iterating its row cursor; resolveRepoRoot picks
+// it up from the same ctx (or any derived ctx, including the timeout
+// ctx defaultGitFileLastModified creates).
+func withRepoRootResolver(ctx context.Context, r *repoRootResolver) context.Context {
+	return context.WithValue(ctx, repoRootResolverKey{}, r)
+}
+
+// resolveRepoRoot returns the git repo root for dir using the cached
+// resolver attached to ctx, or a one-shot lookup if no resolver is
+// installed. The fall-back keeps callers other than Echoes (and the
+// existing direct unit tests) working without changes.
+func resolveRepoRoot(ctx context.Context, dir string) string {
+	if r, ok := ctx.Value(repoRootResolverKey{}).(*repoRootResolver); ok && r != nil {
+		return r.Resolve(ctx, dir)
+	}
+	return defaultRepoRootLookup(ctx, dir)
 }

--- a/internal/lore/echoes_test.go
+++ b/internal/lore/echoes_test.go
@@ -273,3 +273,82 @@ func TestDefaultGitFileLastModified_OutsideRepo(t *testing.T) {
 		t.Fatalf("expected zero time for non-repo path; got %v", got)
 	}
 }
+
+// TestRepoRootResolver_CachesPerDir verifies the per-batch cache
+// behaviour the issue called out: N entries in the same dir cost one
+// lookup, not N. Different dirs still resolve independently and their
+// cached values do not leak across each other.
+func TestRepoRootResolver_CachesPerDir(t *testing.T) {
+	r := newRepoRootResolver()
+	calls := map[string]int{}
+	r.lookup = func(_ context.Context, dir string) string {
+		calls[dir]++
+		switch dir {
+		case "/repo-a/sub":
+			return "/repo-a"
+		case "/repo-b/sub":
+			return "/repo-b"
+		case "/not-a-repo":
+			return "" // empty result is itself a cache entry
+		}
+		return ""
+	}
+
+	ctx := context.Background()
+
+	// Same dir resolved 5 times -> 1 lookup, 4 cache hits.
+	for i := 0; i < 5; i++ {
+		if got := r.Resolve(ctx, "/repo-a/sub"); got != "/repo-a" {
+			t.Fatalf("call %d: got %q, want /repo-a", i, got)
+		}
+	}
+
+	// Different dir -> separate lookup, separate cache slot.
+	if got := r.Resolve(ctx, "/repo-b/sub"); got != "/repo-b" {
+		t.Fatalf("repo-b: got %q, want /repo-b", got)
+	}
+
+	// Empty result also cached; second call must not re-shell.
+	for i := 0; i < 3; i++ {
+		if got := r.Resolve(ctx, "/not-a-repo"); got != "" {
+			t.Fatalf("not-a-repo call %d: got %q, want empty", i, got)
+		}
+	}
+
+	if calls["/repo-a/sub"] != 1 {
+		t.Errorf("repo-a/sub: %d lookups, want 1", calls["/repo-a/sub"])
+	}
+	if calls["/repo-b/sub"] != 1 {
+		t.Errorf("repo-b/sub: %d lookups, want 1", calls["/repo-b/sub"])
+	}
+	if calls["/not-a-repo"] != 1 {
+		t.Errorf("not-a-repo: %d lookups, want 1 (empty result must cache)", calls["/not-a-repo"])
+	}
+}
+
+// TestRepoRootResolver_ContextThreading verifies that resolveRepoRoot
+// finds the resolver attached to a parent context even when called
+// with a derived (timeout-scoped) context — the realistic shape
+// defaultGitFileLastModified produces.
+func TestRepoRootResolver_ContextThreading(t *testing.T) {
+	r := newRepoRootResolver()
+	var calls int
+	r.lookup = func(_ context.Context, _ string) string {
+		calls++
+		return "/repo"
+	}
+
+	parent := withRepoRootResolver(context.Background(), r)
+	derived, cancel := context.WithTimeout(parent, time.Second)
+	defer cancel()
+
+	for i := 0; i < 3; i++ {
+		if got := resolveRepoRoot(derived, "/d"); got != "/repo" {
+			t.Fatalf("call %d: got %q, want /repo", i, got)
+		}
+	}
+
+	if calls != 1 {
+		t.Errorf("got %d lookups across the batch, want 1", calls)
+	}
+}


### PR DESCRIPTION
Closes #50.

The git-aware staleness probe shelled out twice per lore entry: once to \`git rev-parse --show-toplevel\` and once to \`git log -1 --format=%aI -- <path>\`. For a list of N entries in the same repo (the common case for \`lore echo\`) that's 2N subprocess spawns when N+1 is achievable.

Adds a \`repoRootResolver\` that memoizes the rev-parse result per unique parent directory. \`Echoes()\` installs one resolver per call via context, and \`defaultGitFileLastModified\` picks it up through a context value. Empty results are cached too, so a non-repo path also costs one subprocess across the batch.

The resolver lives only for the lifetime of the \`Echoes()\` call so state cannot leak between batches or across repos. Direct callers of \`defaultGitFileLastModified\` (the existing single-call test) get the unchanged one-shot fall-back when no resolver is attached.

Out of scope per the issue: replacing \`git\` subprocess with a native implementation, broader caching of other git operations.

Verified locally:
- \`go test ./internal/lore/... -count=1 -race\` passes
- Two new unit tests cover (a) per-dir cache, including caching of empty results, and (b) context threading from the parent ctx through the timeout-derived ctx \`defaultGitFileLastModified\` creates
- The pre-existing \`TestInit_*\` failures in \`internal/install\` reproduce on \`main\` without this change (they need the \`guild\` binary on PATH and aren't related)