### PR TITLE
docs(readme): highlight hybrid BM25 + vector retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## What Is It
 
-`guild` is a single compiled Go binary containing a first-class MCP server backed by embedded SQLite. State lives strictly on local host; nothing leaves your machine.
+`guild` is a single compiled Go binary containing a first-class MCP server backed by embedded SQLite. State lives strictly on local host; nothing leaves your machine. Search blends keyword (BM25) with vector similarity, fused via reciprocal-rank fusion, so "how did we do X last time" surfaces both exact-term and semantic neighbors.
 
 Guild is designed to be operated autonomously by the agents, for the agents. Guildmasters (us humans) stay in the loop for important decisions and course corrections. Any MCP client — Claude Code, Codex, Cursor, etc. — can act as a Gate into the substrate. This lets parallel agents across different editors share context safely, using atomic locks to claim tasks without stepping on each other.
 
@@ -132,8 +132,10 @@ guild lore inscribe "token refresh window" \
 guild quest journal QUEST-42 "switched to exponential backoff after mock-clock test"
 ```
 
-`lore appraise` is the discipline that keeps guild sharp — search
+`lore appraise` is the discipline that keeps guild sharp: search
 before you research, so knowledge accretes instead of duplicating.
+Appraise runs hybrid (BM25 + vector RRF) the moment your corpus is
+indexed.
 
 ### Act 3 — parting
 
@@ -185,7 +187,10 @@ Four primitives. Everything else in guild is a composition of these.
   (`observation`, `decision`, `research`, `principle`, `idea`). Each
   kind has its own default lifecycle: research auto-stales after 30
   days, decisions after 180 days, and ideas, observations, and
-  principles do not auto-stale by default.
+  principles do not auto-stale by default. Search runs both arms
+  (lexical BM25 + vector cosine) once the corpus is indexed. The
+  embedder backfills automatically; hybrid retrieval activates once
+  at least 90% of entries have vectors.
 - **Oath** — the subset of lore with `kind=principle`. Auto-loaded
   at the top of every session so every agent starts bound by the
   same principles.


### PR DESCRIPTION
## Summary
- Surface hybrid retrieval (BM25 + vector cosine fused via RRF) in *What Is It* and *How it works*, not only as a `go install` caveat in the install section.
- Three surgical edits, no structural change, no new section, no version-specific copy.
- Describes current behavior; safe across future releases.

## What changed
- **`What Is It`**: one sentence on hybrid search and the "how did we do X last time" use case.
- **Act 2 commentary**: note that `lore appraise` runs hybrid once the corpus is indexed.
- **Lore primitive (How it works)**: extend with two-arm search, auto-backfill, and the 90% activation threshold.

## Why now
The retrieval upgrade landed in v0.3.1 but was only visible from the install section's contrast against `go install` (BM25-only). Cold readers evaluating guild from `What Is It` had no way to learn the tool does semantic search.

## What I deliberately did NOT do
- No "v0.3.1 added" marketing copy. Version-specific phrasing rots; the README should describe what the tool does now.
- No removal of pre-existing em dashes elsewhere; out of scope.
- No touching the install section. The existing brew/curl-vs-`go install` contrast is correct.

## Test plan
- [ ] README renders correctly on github.com (preview after merge)
- [ ] No broken links or formatting regressions