### PR TITLE
fix(hints): drop principle-too-long rule (covered by inline inscribe warning)

### DIFF
--- a/internal/hints/detectors.go
+++ b/internal/hints/detectors.go
@@ -266,35 +266,6 @@ func followQuestUpdateOrJournal(_ *Context, ev CallEvent) bool {
 }
 
 // -----------------------------------------------------------------------
-// ℹ️ fyi — principle-too-long
-// -----------------------------------------------------------------------
-
-// principleMaxWords is the oath-hygiene target from ENTRY-21 / the ≤60-word
-// oath principle. Mirrors lore.PrincipleMaxWordsDefault.
-const principleMaxWords = 60
-
-// triggerPrincipleTooLong fires on lore_inscribe(kind=principle) whose
-// title+summary word count exceeds the principle bound.
-func triggerPrincipleTooLong(_ *Context, ev CallEvent) bool {
-	kind := strings.ToLower(strings.TrimSpace(ev.StringArg("kind")))
-	if kind != "principle" {
-		return false
-	}
-	title := strings.TrimSpace(ev.StringArg("title"))
-	summary := strings.TrimSpace(ev.StringArg("summary"))
-	if title == "" && summary == "" {
-		return false
-	}
-	return wordCount(title)+wordCount(summary) > principleMaxWords
-}
-
-// followPrincipleShortened hits on a later lore_update or lore_reforge
-// targeting a lore entry — the agent has done SOMETHING to tighten up.
-func followPrincipleShortened(_ *Context, ev CallEvent) bool {
-	return ev.Tool == "lore_update" || ev.Tool == "lore_reforge"
-}
-
-// -----------------------------------------------------------------------
 // ℹ️ fyi — inscribe-without-transfer-reasoning
 // -----------------------------------------------------------------------
 //

--- a/internal/hints/detectors_test.go
+++ b/internal/hints/detectors_test.go
@@ -399,30 +399,3 @@ func TestTrigger_InscribeWithoutTransferReasoning_InformsShapes(t *testing.T) {
 		})
 	}
 }
-
-// TestTrigger_PrincipleTooLong keys on kind AND wordcount.
-func TestTrigger_PrincipleTooLong(t *testing.T) {
-	long := strings.Repeat("word ", 70) // 70 words > principleMaxWords (60)
-	short := "short oath"
-
-	// Non-principle kind → never fire.
-	if triggerPrincipleTooLong(nil, CallEvent{
-		Args: map[string]any{"kind": "decision",
-			"title": "t", "summary": long}}) {
-		t.Error("non-principle should not fire")
-	}
-
-	// Principle + short → no fire.
-	if triggerPrincipleTooLong(nil, CallEvent{
-		Args: map[string]any{"kind": "principle",
-			"title": short, "summary": short}}) {
-		t.Error("short principle should not fire")
-	}
-
-	// Principle + long → fire.
-	if !triggerPrincipleTooLong(nil, CallEvent{
-		Args: map[string]any{"kind": "principle",
-			"title": short, "summary": long}}) {
-		t.Error("long principle should fire")
-	}
-}

--- a/internal/hints/engine_test.go
+++ b/internal/hints/engine_test.go
@@ -56,7 +56,6 @@ func TestEngine_LoadRules_SeededFromMigration(t *testing.T) {
 		"no-brief-24h",
 		"inscribe-without-appraise",
 		"clear-without-report-detail",
-		"principle-too-long",
 		"inscribe-without-transfer-reasoning",
 	}
 	for _, id := range wantRules {
@@ -139,10 +138,6 @@ func TestEngine_Evaluate_FYICap(t *testing.T) {
 	}
 	eng.Context().RecordEvent(CallEvent{Tool: "guild_session_start"})
 
-	// Fire the principle-too-long rule (a fyi rule) repeatedly by
-	// toggling the payload to dodge cooldown — we override cooldown by
-	// waiting past it instead.
-	longSummary := strings.Repeat("word ", 70)
 	for i := 0; i < 5; i++ {
 		// Advance call count to clear 5-call cooldown.
 		for j := 0; j < 6; j++ {
@@ -151,9 +146,9 @@ func TestEngine_Evaluate_FYICap(t *testing.T) {
 		eng.Evaluate(context.Background(), CallEvent{
 			Tool: "lore_inscribe",
 			Args: map[string]any{
-				"kind":    "principle",
-				"title":   "some title",
-				"summary": longSummary,
+				"kind":    "decision",
+				"title":   "some decision title",
+				"summary": "some short summary that does not trigger the principle bloat path",
 			},
 		})
 	}

--- a/internal/hints/rules.go
+++ b/internal/hints/rules.go
@@ -93,7 +93,7 @@ func Definitions() []Rule {
 			Caveat:        "Era-aware severity: 💡 hint on MCP, ℹ️ fyi on Bash CLI (18.7pp gap in ENTRY-29 calibration).",
 		},
 
-		// ℹ️ fyi (demote) — 4 rules.
+		// ℹ️ fyi (demote) — 3 rules.
 		{
 			ID:            "inscribe-without-appraise",
 			TriggerTool:   "lore_inscribe",
@@ -107,13 +107,6 @@ func Definitions() []Rule {
 			Trigger:       triggerClearWithoutReportDetail,
 			FollowThrough: followQuestUpdateOrJournal,
 			Caveat:        "Demoted to fyi; short reports are legitimate for trivial clears.",
-		},
-		{
-			ID:            "principle-too-long",
-			TriggerTool:   "lore_inscribe",
-			Trigger:       triggerPrincipleTooLong,
-			FollowThrough: followPrincipleShortened,
-			Caveat:        "Demoted to fyi; the 60-word bound mirrors lore's PrincipleMaxWordsDefault hygiene warning.",
 		},
 		{
 			ID:            "inscribe-without-transfer-reasoning",

--- a/internal/hints/rules_test.go
+++ b/internal/hints/rules_test.go
@@ -17,7 +17,6 @@ func TestDefinitions_LaunchSet10(t *testing.T) {
 		"no-brief-24h":                        true,
 		"inscribe-without-appraise":           true,
 		"clear-without-report-detail":         true,
-		"principle-too-long":                  true,
 		"inscribe-without-transfer-reasoning": true,
 	}
 	if len(defs) != len(want) {

--- a/internal/mcp/hints_e2e_test.go
+++ b/internal/mcp/hints_e2e_test.go
@@ -128,7 +128,7 @@ func TestHints_E2E_SlugQuery_OnlyOnZeroResult(t *testing.T) {
 
 	// Seed one lore entry whose title matches the upcoming slug query so
 	// the search returns at least one hit. Use kind=observation so no
-	// other hint (principle-too-long, inscribe-looks-like-quest) tries to
+	// other hint (inscribe-looks-like-quest) tries to
 	// win the budget slot.
 	if _, err := client.CallTool(ctx, &sdkmcp.CallToolParams{
 		Name: "lore_inscribe",

--- a/internal/storage/migrations/008_drop_principle_too_long_hint.up.sql
+++ b/internal/storage/migrations/008_drop_principle_too_long_hint.up.sql
@@ -1,0 +1,10 @@
+-- 008: drop the retired `principle-too-long` hint row.
+--
+-- The hints-engine rule was removed (see #52); the inline ⚠️ warning emitted
+-- by lore_inscribe already covers the same condition with entry-specific
+-- context (word count + remedy command). Without this migration, fresh and
+-- upgraded databases keep an enabled row that surfaces in `guild hints list`
+-- and `guild hints stats` but can never fire because the rule isn't in
+-- internal/hints/rules.go::Definitions().
+
+DELETE FROM hints WHERE rule_id = 'principle-too-long';

--- a/tests/integration/bloat_warn_test.go
+++ b/tests/integration/bloat_warn_test.go
@@ -145,3 +145,40 @@ func TestBloatWarn_NoWarnFlag(t *testing.T) {
 		"--no-warn must suppress the bloat warning")
 	assertContains(t, inv.Stdout, "inscribed", "stdout must confirm insert with --no-warn")
 }
+
+// TestBloatWarn_OnlyOneWarning verifies that the inscribe-time ⚠️ warning
+// is the only warning surfaced for an over-length principle — the
+// hints-engine `principle-too-long` rule has been removed in favor of
+// the inline warning. Regression guard for #52.
+func TestBloatWarn_OnlyOneWarning(t *testing.T) {
+	ctx := context.Background()
+	homeDir := t.TempDir()
+	projDir := filepath.Join(homeDir, "single-warn-proj")
+	_ = initProject(ctx, t, homeDir, projDir)
+
+	// Same fixture as TestBloatWarn_LongPrinciple — guaranteed >60 words.
+	title := "long principle title that already uses ten distinct words for the test"
+	summary := "principles bloat the session-start oath wall when their combined title and summary word count exceeds sixty words which happens frequently when agents encode policy as verbose prose rather than as short memorable behavioral rules that actually fit into a session context window without burning tokens on every single session start call"
+
+	inv := inscribe(ctx, t, homeDir, projDir, title, "principle", summary, "hygiene")
+	assertExitOK(t, inv, "long principle inscribe (single-warning)")
+
+	// Exactly one ⚠️ "principle exceeds" line on stderr.
+	exceedCount := strings.Count(inv.Stderr, "principle exceeds")
+	if exceedCount != 1 {
+		t.Errorf("stderr contains %d 'principle exceeds' lines, want exactly 1\nstderr:\n%s",
+			exceedCount, inv.Stderr)
+	}
+
+	// No hints-engine principle-too-long fire on either channel.
+	for _, name := range []string{"stderr", "stdout"} {
+		stream := inv.Stderr
+		if name == "stdout" {
+			stream = inv.Stdout
+		}
+		if strings.Contains(stream, "principle-too-long") {
+			t.Errorf("%s mentions hints-engine rule 'principle-too-long' (rule was removed):\n%s",
+				name, stream)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Removes the duplicate `principle-too-long` warning surfaced for over-length principle inscribes (#52). Keeps the inline `⚠️` from `formatInscribedWarnings`/`formatInscribedMCP` (`internal/lore/inscribe_cmd.go:152, 180`) and drops the hints-engine `ℹ️ fyi` rule that fired the same condition. The inline surface is the canonical one because it carries the actual word count and a `remedy: lore_update(entry_id=N, kind="decision")` follow-up — the engine fyi was a strictly weaker copy of the same information, and its own caveat already noted "the 60-word bound mirrors lore's PrincipleMaxWordsDefault hygiene warning."

## Linked quest or issue

Closes #52

## Test plan

- [x] `go test ./internal/hints/...` passes (rules_test, engine_test, detectors_test all updated; FYI-cap test rewired to `inscribe-without-appraise` since the cap behavior is rule-independent).
- [x] `go test ./tests/integration/... -run TestBloatWarn` passes — existing `TestBloatWarn_LongPrinciple`/`_ShortPrinciple`/`_NonPrinciple`/`_NoWarnFlag` still green; new `TestBloatWarn_OnlyOneWarning` asserts exactly one `principle exceeds` line on stderr and no `principle-too-long` mention on either channel.
- [x] `go test ./internal/storage/...` and `./internal/mcp/...` pass with the new migration (`008_drop_principle_too_long_hint.up.sql`) deleting the seeded row that 001_init left in the `hints` table — without it, `guild hints list/stats` would keep showing a rule that can't fire.
- [x] `go vet ./...` clean.

Pre-existing failure: `internal/install` `TestInit_*` tests fail on `upstream/main` too (they require a `guild` binary on PATH), unrelated to this diff.

## Notes for reviewers

- Two commits: the rule removal and the migration. They could be squashed at merge.
- The dedup choice is documented in the first commit message and in the new test's comment so it's preserved as code archaeology.
- I went with rule removal rather than rule-disable so the rule code can't drift back into accidental use. If you'd rather keep the rule definition around in a `disabled` collection for future calibration work, happy to follow up.

This contribution was developed with AI assistance (Codex).
