### PR TITLE
test(install): make internal/install tests hermetic

### DIFF
--- a/internal/install/clients_test.go
+++ b/internal/install/clients_test.go
@@ -94,7 +94,7 @@ func TestClients_WellFormed(t *testing.T) {
 		}
 		if c.InstallArgv == nil {
 			t.Errorf("client %q has nil InstallArgv", c.Name)
-		} else if argv := c.InstallArgv("/usr/local/bin/guild"); len(argv) == 0 {
+		} else if argv := c.InstallArgv(filepath.Join(t.TempDir(), "guild")); len(argv) == 0 {
 			t.Errorf("client %q InstallArgv returned empty slice", c.Name)
 		}
 		if c.CLIProbe == "" && c.ConfigProbe == "" {

--- a/internal/install/init_test.go
+++ b/internal/install/init_test.go
@@ -67,17 +67,23 @@ func testDBPaths(t *testing.T) (loreDB, questDB string) {
 	return filepath.Join(dir, "lore.db"), filepath.Join(dir, "quest.db")
 }
 
-// newOpts returns InitOptions with output captured, test-local DBs, and --yes
-// so tests don't block on interactive prompts.
+// newOpts returns InitOptions with output captured, test-local DBs, --yes
+// so tests don't block on interactive prompts, and a fakeExecutable so the
+// MCP registration step's resolveAbsBinPath does not require a real
+// system-installed guild binary. Without this injection, any environment
+// without a prior `guild` install (CI runners, fresh dev boxes, Nix, etc.)
+// fails every Init test with "guild binary not found in any durable
+// location" — see #49.
 func newOpts(t *testing.T, buf *bytes.Buffer) InitOptions {
 	t.Helper()
 	loreDB, questDB := testDBPaths(t)
 	return InitOptions{
-		Yes:         true,
-		Out:         buf,
-		In:          &bytes.Buffer{},
-		LoreDBPath:  loreDB,
-		QuestDBPath: questDB,
+		Yes:          true,
+		Out:          buf,
+		In:           &bytes.Buffer{},
+		LoreDBPath:   loreDB,
+		QuestDBPath:  questDB,
+		executableFn: fakeExecutable(t),
 	}
 }
 
@@ -281,11 +287,12 @@ func TestInit_YesFlag_NonInteractive(t *testing.T) {
 	var out bytes.Buffer
 
 	_, err := Init(ctx, dir, InitOptions{
-		Yes:         true,
-		Out:         &out,
-		In:          &bytes.Buffer{},
-		LoreDBPath:  loreDB,
-		QuestDBPath: questDB,
+		Yes:          true,
+		Out:          &out,
+		In:           &bytes.Buffer{},
+		LoreDBPath:   loreDB,
+		QuestDBPath:  questDB,
+		executableFn: fakeExecutable(t),
 	})
 	if err != nil {
 		t.Fatalf("Init --yes: %v", err)
@@ -403,11 +410,12 @@ func TestInit_MultipleRuns_NoDuplicateSections(t *testing.T) {
 		t.Helper()
 		var out bytes.Buffer
 		if _, err := Init(ctx, dir, InitOptions{
-			Yes:         true,
-			Out:         &out,
-			In:          &bytes.Buffer{},
-			LoreDBPath:  loreDB,
-			QuestDBPath: questDB,
+			Yes:          true,
+			Out:          &out,
+			In:           &bytes.Buffer{},
+			LoreDBPath:   loreDB,
+			QuestDBPath:  questDB,
+			executableFn: fakeExecutable(t),
 		}); err != nil {
 			t.Fatalf("Init: %v", err)
 		}


### PR DESCRIPTION
Closes #49.

Without this change every `internal/install/Init...` test fails on any machine that doesn't have a real `guild` binary already on disk:

```
init_test.go:95: Init: install: mcp register: mcp install:
  resolve binary path: guild binary not found in any durable location;
  run `go install` or install via your package manager
```

The cause is the same in both files the issue points at — the test path leaks into a real install probe. Two test changes, no production code touched:

## clients_test.go

Replaces the literal `"/usr/local/bin/guild"` argument to `InstallArgv()` in `TestClients_WellFormed` with `filepath.Join(t.TempDir(), "guild")`. The test only checks that the argv is non-empty for an arbitrary binary path, so a tempdir path works as well as a hard-coded one.

## init_test.go

The `Init` tests already had a `fakeExecutable(t)` helper but only some of them were using it. The default `newOpts()` helper plus two inline `InitOptions{...}` literals (`TestInit_YesFlag_NonInteractive`, `TestInit_MultipleRuns_NoDuplicateSections`) didn't pass an `executableFn`, so the install code fell through to `os.Executable` -> not found -> the durable-location probe -> not found -> error.

This PR plumbs `executableFn: fakeExecutable(t)` into the shared `newOpts()` helper and the two inline literals, so every `Init` test path now exercises a tempdir-backed fake binary.

## Verification

On this machine (no system `guild` binary on PATH):

```
go test ./internal/install/        # ok 1.4s
go test -race ./internal/install/  # ok 3.2s
```

## Out of scope

The `/usr/local/bin/guild` mentions in `mcp_install.go` are illustrative comments for the install command and untouched per the issue's "only the tests" scope.