### PR TITLE
fix(hints): close outgoing hints.Engine DB handle before swapping

### DIFF
--- a/internal/hints/engine.go
+++ b/internal/hints/engine.go
@@ -127,6 +127,17 @@ func (e *Engine) Context() *Context {
 	return e.context
 }
 
+// Close releases resources held by the engine — specifically the
+// Store's *sql.DB handle. Safe to call on a nil engine or on an engine
+// whose Store/DB is nil. Returns the underlying sql.DB.Close() error
+// when applicable.
+func (e *Engine) Close() error {
+	if e == nil || e.Store == nil || e.Store.DB == nil {
+		return nil
+	}
+	return e.Store.DB.Close()
+}
+
 // Fire is the result of an Evaluate call. Empty Fire (zero-value) means
 // no hint should be rendered.
 type Fire struct {

--- a/internal/mcp/hints.go
+++ b/internal/mcp/hints.go
@@ -30,6 +30,17 @@ var currentHintsEngine *hints.Engine
 //
 //nolint:contextcheck // called during Register (no per-request ctx); writes use per-Evaluate ctx later
 func initHintsEngine() *hints.Engine {
+	// Close any prior engine's DB before opening a new one. The package
+	// stores the engine in currentHintsEngine; we own it through Register
+	// rebuilds and must release the underlying *sql.DB handle when we
+	// drop our reference.
+	if prev := currentHintsEngine; prev != nil {
+		if err := prev.Close(); err != nil {
+			slog.Debug("mcp: hints: closing previous engine failed", "err", err)
+		}
+		currentHintsEngine = nil
+	}
+
 	ctx := context.Background()
 
 	db, err := openQuestDB(ctx)

--- a/internal/mcp/register.go
+++ b/internal/mcp/register.go
@@ -15,6 +15,12 @@ import (
 func Register(s *sdkmcp.Server) {
 	// Reset so hintsBridge builds one engine per server rebuild and all
 	// Deps builders in this Register share it. See hints.go comment.
+	// Close any prior engine's DB before zeroing — Register is the
+	// single drop site that runs before initHintsEngine on the next
+	// hintsBridge call. See internal/hints/engine.go::Close.
+	if prev := currentHintsEngine; prev != nil {
+		_ = prev.Close()
+	}
 	currentHintsEngine = nil
 	// The embedder port (ADR-003 Phase 1, QUEST-219 lazy-reconstruct)
 	// is wired as a provider, not a static *EmbedDeps. The provider


### PR DESCRIPTION
## Summary

`internal/hints/store.go` documents that the caller is responsible for opening and closing the underlying `*sql.DB`. The MCP wiring was holding up its end on open but not on close: `initHintsEngine` reassigned `currentHintsEngine` without releasing the prior engine's DB, and `Register()` zeroed `currentHintsEngine` at entry without closing it either. On long-running server processes this leaked handles to the hints store until the GC finalizer ran. This PR adds a nil-safe `Engine.Close` and calls it at both drop sites.

## Linked quest or issue

Closes #51

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean for the three changed files
- [x] `go test ./internal/hints/... ./internal/mcp/...` passes
- [ ] `make check` passes locally (fmt + vet + lint + sqlcheck + test-race)
- [ ] New behavior covered by a test
- [ ] Manually exercised via `guild` CLI or MCP client (describe below)

The bug is observable on long-running MCP server processes (handles to the hints store accumulate across config reloads / project switches), which is hard to reproduce inside a unit test without a long-lived MCP harness. The change is purely additive cleanup wired into two existing drop sites, and the existing `internal/hints` and `internal/mcp` test suites both pass. If a regression test would help, I am happy to add one against `Engine.Close` directly (verifying the underlying `*sql.DB` reports an error on subsequent use after Close); flag if you would like that on the same PR.

## Notes for reviewers

The Close method follows the nil-safety convention the rest of `Engine` already uses (`LoadRules`, `Context`, `Evaluate` all early-return on `e == nil`). Both `initHintsEngine` and `Register()` are now defensive against a stale `currentHintsEngine`: each closes-then-nils before opening or zeroing, so the package-level pointer is never zeroed without first releasing the underlying handle. If there are other paths that drop the pointer that I missed, please point me at them.
