### PR TITLE
docs: document Stacked on: #N PR body convention for stacked PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,8 @@ small fix, open an issue or Discussion first.
 ## Summary
 
 <!-- One or two sentences on what this PR does and why. -->
+<!-- If this PR is stacked on an in-flight PR (i.e. base is not `main`),
+     add "Stacked on: #N" near the top so reviewers see the dependency. -->
 
 ## Linked quest or issue
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ it reaches 1.0.
 
 ## [Unreleased]
 
+### Documentation
+
+- Document the `Stacked on: #N` PR body convention for non-main-based PRs (CONTRIBUTING.md, PR template).
+
 ## [0.3.1] - 2026-04-24
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,6 +101,24 @@ right kind for each inscribe). Follow it.
 - Update `CHANGELOG.md` under `## [Unreleased]` if your change is
   user-visible.
 
+### Stacked PRs
+
+If you open a PR against a branch other than `main` (because it
+depends on an in-flight PR), put a `Stacked on: #N` line near the top
+of the PR body so reviewers can see the dependency without reading the
+base ref. Example:
+
+```
+## Summary
+
+Adds the `--shallow` flag to `guild lore appraise`.
+
+Stacked on: #61
+```
+
+The convention is human-only for now -- there is no enforcing bot or
+action.
+
 ## Adding dependencies
 
 Don't, unless essential. Every new module is a supply-chain surface and


### PR DESCRIPTION
## Summary

Documents the human-only `Stacked on: #N` convention for non-`main`-based PRs in three places: `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `CHANGELOG.md`.

## Linked quest or issue

Closes #45

## Test plan

- [x] `make check` -- `gofmt` clean, `go vet` clean. `golangci-lint` fails on a pre-existing config-version issue unrelated to this change (no `.golangci.yml` is touched).
- [x] No code paths affected.
- [x] CONTRIBUTING.md renders correctly with the new `### Stacked PRs` subsection inside `## Pull requests`.

## Notes for reviewers

- Per the issue's "Not in scope" section, this is documentation only -- no enforcing action / bot is added.
- The PR template hint is an HTML comment so it does not appear in rendered PR bodies; it only helps the author when filling in the template.
- Could trim the CHANGELOG entry if you'd rather skip changelog noise for contributor-facing docs. Easy follow-up.