### PR TITLE
docs: simplify headline positioning, drop 'cognition substrate' framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The Agent Guild
 
-**A local-first, persistent cognition substrate for AI agents.**
+**Shared context, memory, and task coordination for AI coding agents.**
 
 [![CI](https://github.com/mathomhaus/guild/actions/workflows/ci.yml/badge.svg)](https://github.com/mathomhaus/guild/actions/workflows/ci.yml)
 [![Go 1.25](https://img.shields.io/badge/go-1.25-blue)](https://go.dev)

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -29,7 +29,7 @@ func SetVersion(version, commit, date string) {
 
 var rootCmd = &cobra.Command{
 	Use:   "guild",
-	Short: "persistent cognition for AI agents — task + knowledge lifecycle",
+	Short: "shared context, memory, and task coordination for AI coding agents",
 	Long: `guild bundles three modes in one static binary:
 
   guild lore <verb>    knowledge lifecycle (inscribe, appraise, study, ...)


### PR DESCRIPTION
## Summary

Swaps the README headline and `guild --help` Short line away from "cognition substrate" toward language that names the three category words readers are already searching for: **"Shared context, memory, and task coordination for AI coding agents."**

The motivation is reader-facing legibility. "Cognition substrate" is a precise internal label for the layer guild occupies in the agent-tooling stack, but it requires a paragraph of unpacking before a first-time reader knows what guild *does*. The new line names the categories (context, memory, task coordination) without losing buyer specificity ("AI coding agents", not the more generic "AI agents").

## What changed

| File | Change |
|---|---|
| `README.md:3` | Headline replaced. |
| `internal/cli/root.go:32` | `cobra.Command.Short` (the line printed by `guild --help`) replaced. |

The README body, mythos section, and four-primitive language (lore / quest / oath / brief) are unchanged. The in-body "Gate into the substrate" reference is preserved because there it functions as a referential noun, not as a category label.

`CHANGELOG.md` is intentionally untouched: rewriting prior entries is bad form.

## Test plan

- [x] `git diff` reviewed: 2 files, +2/-2, no incidental edits
- [x] No code paths affected; `internal/cli/root.go` change is a string literal in the cobra command's Short field
- [x] `make check` will run in CI (fmt + vet + lint + sqlcheck + test-race)

## Notes for reviewers

If you'd rather collapse the in-body "Gate into the substrate" wording too, that is a one-line follow-up. Held back here so the PR stays minimal.