### PR TITLE
fix(lore): discard stale vector index snapshots that raced a concurrent splice

### DIFF
--- a/internal/lore/embed/index.go
+++ b/internal/lore/embed/index.go
@@ -231,6 +231,17 @@ func (i *Index) LoadFromDB(ctx context.Context, db *sql.DB) (int, error) {
 		}
 	}
 
+	// Read the epoch BEFORE scanning rows so it is a lower bound for
+	// the snapshot: every commit visible to the SELECT below happened
+	// at or after this epoch. Reading it after the scan inverts that
+	// bound and lets a concurrent writer's commit land between the two
+	// reads, stamping a pre-commit row snapshot with a post-commit
+	// epoch; CheckAndReload then trusts the stale snapshot forever.
+	epoch, err := readEpoch(ctx, db, i.corpus.MetaKey(FieldVectorEpoch))
+	if err != nil {
+		return 0, err
+	}
+
 	// Stream the corpus's vector table in one SELECT. entry_id is the
 	// PK so the default ordering is by id; that is fine for parallel-
 	// slice layout and gives tests a deterministic load order.
@@ -290,14 +301,22 @@ func (i *Index) LoadFromDB(ctx context.Context, db *sql.DB) (int, error) {
 		return 0, fmt.Errorf("embed/index: iterate %s: %w", i.corpus.VectorTable(), err)
 	}
 
-	// Refresh epoch from meta using the corpus's meta key. A missing
-	// row (fresh DB) yields 0.
-	epoch, err := readEpoch(ctx, db, i.corpus.MetaKey(FieldVectorEpoch))
-	if err != nil {
-		return 0, err
-	}
-
 	i.bindMu.Lock()
+	if i.loaded && epoch < i.cachedEpoch {
+		// A concurrent Splice advanced the index past this snapshot
+		// (its writer committed after our epoch read). Installing the
+		// snapshot would silently drop that newer vector. Discard;
+		// the in-memory state is already at least as fresh as the DB
+		// state this load observed.
+		cached := i.cachedEpoch
+		i.bindMu.Unlock()
+		i.logger.Debug("embed/index: discarded stale load snapshot",
+			"snapshot_epoch", epoch,
+			"cached_epoch", cached,
+			"rows", len(newVecs),
+		)
+		return len(newVecs), nil
+	}
 	i.vectors = newVecs
 	i.entries = newEntries
 	i.byEntry = newByID

--- a/internal/lore/embed/index_test.go
+++ b/internal/lore/embed/index_test.go
@@ -316,6 +316,47 @@ func TestIndex_CheckAndReload_ReloadsOnEpochBump(t *testing.T) {
 	}
 }
 
+// TestIndex_LoadFromDB_DiscardsSnapshotOlderThanSplice: a load whose
+// DB snapshot predates a concurrent Splice must not clobber the newer
+// in-memory state. Deterministic reconstruction of the interleaving
+// behind the Test_ConcurrentInscribeAndAppraise lost-Splice flake: the
+// reader's SELECT ran before the writer's commit, the writer's Splice
+// landed first, then the reader's stale snapshot tried to install.
+func TestIndex_LoadFromDB_DiscardsSnapshotOlderThanSplice(t *testing.T) {
+	ctx := context.Background()
+	db := openEmbedTestDB(t)
+	mustSeedEntry(t, db, 1, "e1")
+	mustInsertVec(t, db, 1, canonModelID, Quantize(deterministicUnitVec(1)))
+	mustSetEpoch(t, db, 1)
+
+	idx := NewIndex(LoreCorpus{}, canonModelID)
+	if _, err := idx.LoadFromDB(ctx, db); err != nil {
+		t.Fatalf("LoadFromDB: %v", err)
+	}
+
+	// Writer path: Splice entry 2 at epoch 2. The DB row + epoch bump
+	// are deliberately NOT written, so the DB still holds the epoch-1
+	// single-row state, i.e. the stale snapshot a slow reader observes
+	// when its reads ran before the writer's commit.
+	if err := idx.Splice(2, Quantize(deterministicUnitVec(2)), 2); err != nil {
+		t.Fatalf("Splice: %v", err)
+	}
+	if idx.Len() != 2 {
+		t.Fatalf("post-splice Len = %d, want 2", idx.Len())
+	}
+
+	// The late reader's load must be discarded, not installed.
+	if _, err := idx.LoadFromDB(ctx, db); err != nil {
+		t.Fatalf("LoadFromDB (stale): %v", err)
+	}
+	if idx.Len() != 2 {
+		t.Fatalf("stale snapshot clobbered the index: Len = %d, want 2", idx.Len())
+	}
+	if idx.Epoch() != 2 {
+		t.Fatalf("stale snapshot regressed epoch: %d, want 2", idx.Epoch())
+	}
+}
+
 // TestIndex_Splice_InsertNew: Splice on an unknown entry_id appends a
 // new slot and bumps cachedEpoch.
 func TestIndex_Splice_InsertNew(t *testing.T) {


### PR DESCRIPTION
## Problem

Test_ConcurrentInscribeAndAppraise_NoDeadlocksOrLostWrites has been failing intermittently (`index.Len(): got 63, want 64`), and the failure rate worsened recently to the point of blocking unrelated merges.

Root cause in `Index.LoadFromDB`: it read `meta.vector_epoch` after scanning the vector rows, then installed the snapshot unconditionally. Two interleavings break under concurrent writers:

1. A writer commit lands between the row scan and the epoch read. The loader installs a pre-commit row snapshot stamped with the post-commit epoch, so `CheckAndReload` considers the stale state current indefinitely. This is silent permanent staleness in production, not just test noise.
2. A snapshot built before a concurrent `Splice` overwrites the spliced vector on install. This is the lost-Splice test failure.

## Fix

- Read the epoch before the row scan, making it a lower bound for the snapshot.
- Under the write lock, discard the install when the snapshot epoch is strictly older than `cachedEpoch` (a concurrent splice already advanced the in-memory state past it).

## Testing

- New deterministic regression test `TestIndex_LoadFromDB_DiscardsSnapshotOlderThanSplice` reconstructs the interleaving without relying on goroutine timing.
- `go test -race -count=30 ./internal/lore/ -run Test_ConcurrentInscribeAndAppraise` passes 30/30 (pre-fix it reliably failed within 25 iterations on this machine).
- Extended soak running locally; will report results on this PR.