### PR TITLE
ci(deps): drop duplicate scope from dependabot commit prefixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,9 @@
 version: 2
+
+# commit-message.prefix already carries the conventional-commit scope.
+# Do not add `include: scope` alongside it. Dependabot appends its own
+# "(deps)" on top, yielding "chore(deps)(deps): ..." which the PR-hygiene
+# title lint rejects as an unknown scope.
 updates:
   - package-ecosystem: gomod
     directory: /
@@ -12,7 +17,6 @@ updates:
           - "*"
     commit-message:
       prefix: "chore(deps)"
-      include: scope
     labels:
       - dependencies
       - go
@@ -29,7 +33,6 @@ updates:
           - "*"
     commit-message:
       prefix: "chore(ci)"
-      include: scope
     labels:
       - dependencies
       - github-actions


### PR DESCRIPTION
## Problem

Every dependabot PR fails the `semantic PR title` check:

```
Unknown scope "deps)(deps" found in pull request title
"chore(deps)(deps): bump the go-deps group across 1 directory with 5 updates"
```

`.github/dependabot.yml` sets `commit-message.prefix: "chore(deps)"` (which
already contains the scope) **and** `include: scope`, so dependabot appends a
second `(deps)` of its own. Same for the github-actions ecosystem with
`chore(ci)`.

The check is not a required status, so these PRs were merged red (#100, #65).
That trains everyone to ignore a red check on the one PR class nobody reads
closely, which is the wrong habit for a dependency-update stream.

## Fix

Drop `include: scope` from both ecosystems and keep the explicit prefixes.
Next dependabot PR titles become `chore(deps): ...` and `chore(ci): ...`,
both of which the title lint accepts.

A comment above `updates:` records why `include: scope` must not come back.

## Verification

No code paths touched. The two open dependabot PRs were retitled by hand to
the post-fix shape (`chore(deps): bump the go-deps group with 5 updates`,
`chore(ci): bump the actions group with 4 updates`) and the title check went
green on both, which is the same string this config will now produce.