### PR TITLE
fix(install): skip duplicate Codex MCP registration on repeat init

### DIFF
--- a/internal/install/clients.go
+++ b/internal/install/clients.go
@@ -98,8 +98,8 @@ var Clients = []Client{
 		InstallArgv: func(b string) []string {
 			return []string{"codex", "mcp", "add", "guild", "--", b, "mcp", "serve"}
 		},
-		// ListArgv left nil until `codex mcp list` output shape is verified
-		// against a real run; nil disables the pre-check and the install
-		// attempt proceeds as before.
+		// JSON output is stable across Codex versions; the human table layout
+		// varies by transport type. Issue #14.
+		ListArgv: func() []string { return []string{"codex", "mcp", "list", "--json"} },
 	},
 }

--- a/internal/install/mcp_install.go
+++ b/internal/install/mcp_install.go
@@ -28,6 +28,7 @@ package install
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -477,19 +478,14 @@ func isGuildRegistered(execCmdFn func(string, ...string) *exec.Cmd, listArgv []s
 	return scanForGuildEntry(out)
 }
 
-// scanForGuildEntry reports whether stdout contains a line identifying
-// "guild" as a registered MCP server, and extracts the configured command
-// path when the line shape exposes one. Recognised shapes cover the CLI
-// outputs of Claude Code, Cursor, and Codex — "guild:" (Claude / Codex
-// human formats, "guild: <command> <args>"), a bare "guild" token, or a
-// "- guild" list entry. The match is anchored at line start (after
-// trimming leading whitespace and list markers) so a stray occurrence
-// inside a command value doesn't produce a false positive.
-//
-// The returned path is the first whitespace-separated token after the
-// "guild:" prefix, or "" when the line carries no command (bare token,
-// or list-marker shape without a colon).
+// scanForGuildEntry reports whether stdout contains a guild MCP registration,
+// and extracts the configured command path when the line shape exposes one.
+// Recognised shapes cover Claude/Cursor human CLI output ("guild:", bare
+// token, list markers) and Codex `mcp list --json` arrays.
 func scanForGuildEntry(out []byte) (registered bool, cmdPath string) {
+	if registered, cmdPath, parsed := scanGuildFromCodexJSON(out); parsed {
+		return registered, cmdPath
+	}
 	for _, raw := range strings.Split(string(out), "\n") {
 		line := strings.TrimSpace(raw)
 		line = strings.TrimPrefix(line, "- ")
@@ -513,6 +509,36 @@ func scanForGuildEntry(out []byte) (registered bool, cmdPath string) {
 		}
 	}
 	return false, ""
+}
+
+// scanGuildFromCodexJSON parses `codex mcp list --json` output. The second
+// return value is the configured stdio command path when present.
+func scanGuildFromCodexJSON(out []byte) (registered bool, cmdPath string, parsed bool) {
+	trimmed := strings.TrimSpace(string(out))
+	if trimmed == "" || trimmed[0] != '[' {
+		return false, "", false
+	}
+	var entries []struct {
+		Name      string `json:"name"`
+		Transport struct {
+			Type    string `json:"type"`
+			Command string `json:"command"`
+		} `json:"transport"`
+	}
+	if err := json.Unmarshal([]byte(trimmed), &entries); err != nil {
+		return false, "", false
+	}
+	parsed = true
+	for _, entry := range entries {
+		if entry.Name != "guild" {
+			continue
+		}
+		if entry.Transport.Type == "stdio" && entry.Transport.Command != "" {
+			return true, entry.Transport.Command, true
+		}
+		return true, "", true
+	}
+	return false, "", true
 }
 
 // pathComparison enumerates the three states from issue #61.

--- a/internal/install/mcp_install_test.go
+++ b/internal/install/mcp_install_test.go
@@ -697,6 +697,106 @@ func TestScanForGuildEntry(t *testing.T) {
 	}
 }
 
+func TestScanForGuildEntry_CodexJSON(t *testing.T) {
+	cases := []struct {
+		name     string
+		in       string
+		want     bool
+		wantPath string
+	}{
+		{
+			name: "registered stdio",
+			in: `[{"name":"guild","transport":{"type":"stdio","command":"/usr/local/bin/guild","args":["mcp","serve"]}}]`,
+			want: true, wantPath: "/usr/local/bin/guild",
+		},
+		{
+			name: "registered http no command path",
+			in: `[{"name":"guild","transport":{"type":"streamable_http","url":"https://example.com/mcp"}}]`,
+			want: true, wantPath: "",
+		},
+		{
+			name: "other server only",
+			in: `[{"name":"context7","transport":{"type":"stdio","command":"npx"}}]`,
+			want: false, wantPath: "",
+		},
+		{
+			name: "empty list",
+			in: `[]`,
+			want: false, wantPath: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, path := scanForGuildEntry([]byte(tc.in))
+			if got != tc.want {
+				t.Errorf("scanForGuildEntry(%q) found = %v, want %v", tc.in, got, tc.want)
+			}
+			if path != tc.wantPath {
+				t.Errorf("scanForGuildEntry(%q) path = %q, want %q", tc.in, path, tc.wantPath)
+			}
+		})
+	}
+}
+
+// TestMCPInstall_Run_SkipsAlreadyRegistered_Codex verifies that Codex's
+// permissive `mcp add` does not create duplicate guild entries on repeat
+// `guild init --yes` runs once `codex mcp list --json` is wired up (#14).
+func TestMCPInstall_Run_SkipsAlreadyRegistered_Codex(t *testing.T) {
+	var installCalls, listCalls int
+
+	c := alwaysDetected("Codex (OpenAI)", func(b string) []string {
+		return []string{"codex", "mcp", "add", "guild", "--", b, "mcp", "serve"}
+	})
+	c.ListArgv = func() []string { return []string{"codex-mcp-list", "--json"} }
+
+	dir := t.TempDir()
+	fakeBin := dir + "/guild"
+	if err := os.WriteFile(fakeBin, []byte{}, 0o600); err != nil {
+		t.Fatalf("create temp binary: %v", err)
+	}
+
+	jsonOut := `[{"name":"guild","transport":{"type":"stdio","command":"` + fakeBin + `","args":["mcp","serve"]}}]`
+
+	var buf bytes.Buffer
+	opts := MCPInstallOptions{
+		Run:          true,
+		Yes:          true,
+		Out:          &buf,
+		In:           &bytes.Buffer{},
+		clients:      []Client{c},
+		executableFn: func() (string, error) { return fakeBin, nil },
+		execCmdFn: func(name string, arg ...string) *exec.Cmd {
+			switch name {
+			case "codex-mcp-list":
+				listCalls++
+				return exec.Command("printf", "%s", jsonOut)
+			case "codex":
+				installCalls++
+				return exec.Command("true")
+			}
+			return exec.Command("false")
+		},
+		lookPathFn: func(name string) (string, error) { return name, nil },
+	}
+
+	result, err := MCPInstall(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("MCPInstall --run --yes: %v", err)
+	}
+	if listCalls != 1 {
+		t.Errorf("list probe ran %d times, want 1", listCalls)
+	}
+	if installCalls != 0 {
+		t.Errorf("install ran %d times, want 0 (already registered in Codex)", installCalls)
+	}
+	if got := len(result.AlreadyRegistered); got != 1 {
+		t.Errorf("AlreadyRegistered len = %d, want 1", got)
+	}
+	if !strings.Contains(buf.String(), "already registered in Codex (OpenAI)") {
+		t.Errorf("output missing skip notice:\n%s", buf.String())
+	}
+}
+
 // TestMCPInstall_Run_NilListArgv_FallsThrough verifies that a client whose
 // ListArgv is nil (no list-MCP CLI shape known) skips the probe entirely
 // and proceeds with the install as the unconditional first-run path did.


### PR DESCRIPTION
## Summary

Wire `codex mcp list --json` into the MCP install pre-check so repeat `guild init --yes` runs detect an existing `guild` entry and skip re-adding it, matching Claude/Cursor idempotency.

Fixes #14

## Motivation

Codex's `mcp add` succeeds on duplicate entries (unlike `claude mcp add`, which errors with "already exists"). Without a list probe, `guild init` could register `guild` twice in Codex's MCP config.

## Changes

- Add `ListArgv` for Codex (`codex mcp list --json`) in `clients.go`
- Parse Codex JSON list output in `scanGuildFromCodexJSON`, integrated into `scanForGuildEntry`
- Add regression tests for JSON parsing and the Codex skip-already-registered path

## Tests

```bash
go test ./internal/install/... -count=1
```

All install package tests pass (including new `TestScanForGuildEntry_CodexJSON` and `TestMCPInstall_Run_SkipsAlreadyRegistered_Codex`).

## Notes

- HTTP/streamable_http `guild` entries are detected as registered but return an empty command path, so they fall through to install (same as unparseable human-format lines). This is unlikely from `guild init`, which always registers a stdio launcher.
- Malformed JSON or probe failures fall through to install, preserving historical behaviour.